### PR TITLE
Enable SKiDL advanced search queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 Circuitron is an agentic PCB design accelerator that transforms natural language prompts into SKiDL code, KiCad schematics, and routed PCB layouts. It assists professional power-electronics engineers by automating routine steps while keeping humans in the loop for review and approval.
 
+Part selection now leverages SKiDL's full search syntax: queries may contain multiple terms, quoted phrases, regular expressions, and OR pipes for precise component lookup.
+
 
 See [overview.md](overview.md) for detailed project goals and structure.

--- a/src/agent.py
+++ b/src/agent.py
@@ -1,7 +1,7 @@
 import asyncio, json, os
 from .prompts import PLAN_PROMPT, CODEGEN_PROMPT
 from .mcp_client import perform_rag_query, search_code_examples
-from .part_lookup import extract_keywords, lookup_parts
+from .part_lookup import extract_queries, lookup_parts
 from .skidl_exec import run_skidl_script
 from .utils_llm import LLM_PLAN, LLM_CODE, call_llm
 
@@ -17,9 +17,9 @@ async def pipeline(user_req: str):
     if input("\nApprove plan? [y/N] ").lower() != "y":
         print("Aborted."); return
 
-    # B ▸ KEYWORDS → PARTS
-    keywords = await extract_keywords(plan)
-    parts    = lookup_parts(keywords)
+    # B ▸ QUERIES → PARTS
+    queries = await extract_queries(plan)
+    parts   = lookup_parts(queries)
 
     # C ▸ RAG
     rag_ctx  = await _rag(plan)

--- a/src/part_lookup.py
+++ b/src/part_lookup.py
@@ -1,30 +1,45 @@
+"""Utilities for performing advanced SKiDL part searches."""
+
 import re
 from skidl import search
 from .prompts import PART_PROMPT
 from .utils_llm import call_llm, LLM_PART
 
-KEYWORD_RE   = re.compile(r"^[A-Za-z0-9_\-+().]+$")
+# Allow a wide range of characters so the query string can include
+# SKiDL's advanced search syntax (regex, quoted strings, OR logic, etc.).
+QUERY_RE     = re.compile(r"^[A-Za-z0-9_ .+()\-|'\"^$*?\[\]]+$")
 VALID_PARTRE = re.compile(r"^[A-Za-z0-9_]+:[A-Za-z0-9_.+\-]+$")
 
-def _exact_first(keyword: str, max_choices=3):
-    exact = list(search(f"^{keyword}$"))
-    fuzzy = [] if exact else list(search(keyword))
-    hits  = exact + fuzzy
-    out   = []
+def _run_search(query: str, max_choices=3):
+    """Return up to *max_choices* parts matching *query*.
+
+    The query string is passed verbatim to ``skidl.search`` which supports
+    quoted phrases, regular expressions, OR pipes, and multi-term queries.
+    Results are returned as ``{"part": "lib:name", "desc": "description"}``
+    dictionaries.
+    """
+
+    hits = list(search(query))
+    out: list[dict] = []
+    seen = set()
     for p in hits:
         ident = f"{p.lib}:{p.name}"
-        if ident not in out and VALID_PARTRE.match(ident):
-            out.append(ident)
+        if ident in seen or not VALID_PARTRE.match(ident):
+            continue
+        out.append({"part": ident, "desc": getattr(p, "description", "").strip()})
+        seen.add(ident)
         if len(out) >= max_choices:
             break
     return out
 
-async def extract_keywords(plan: str):
-    # pull draft list from plan (lines after "Draft search keywords")
+async def extract_queries(plan: str):
+    """Extract and clean draft search queries from *plan* using the LLM."""
+
+    # pull draft list from plan (lines after the heading)
     draft = []
     grab  = False
     for line in plan.splitlines():
-        if "Draft search keywords" in line:
+        if "Draft search queries" in line or "Draft search keywords" in line:
             grab = True
             continue
         if grab and line.strip():
@@ -34,7 +49,9 @@ async def extract_keywords(plan: str):
     draft_txt = "\n".join(draft)
 
     cleaned = await call_llm(LLM_PART, PART_PROMPT + "\n" + draft_txt)
-    return [kw for kw in cleaned.splitlines() if KEYWORD_RE.match(kw)]
+    return [q.strip() for q in cleaned.splitlines() if q.strip() and QUERY_RE.match(q)]
 
-def lookup_parts(keywords, max_choices=3):
-    return {kw: _exact_first(kw, max_choices) for kw in keywords}
+def lookup_parts(queries, max_choices=3):
+    """Return matching parts for each search query."""
+
+    return {q: _run_search(q, max_choices) for q in queries}

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -8,19 +8,20 @@ OUTPUT
  1. High-level schematic description (bullets)
  2. Design calculations / assumptions (bullets)
  3. Ordered action list (imperative, one per line)
- 4. Draft search keywords (one per line, no footprints, no library prefix)
+ 4. Draft search queries (one per line, no footprints, no library prefix)
 
 Do **NOT** output part numbers or code blocks.
 """
 
-# ---------- Stage B  Keyword cleaner ----------
+# ---------- Stage B  Query cleaner ----------
 PART_PROMPT = """You are **Circuitron-PartCleaner**.
 
-CLEAN the DRAFT keyword list:
+CLEAN the DRAFT search query list:
  • lowercase
  • strip units (e.g., '10uF' → 'uf')
  • remove duplicates
-Return ONE keyword per line, NOTHING else.
+ • keep spaces, quotes, and regex characters intact
+Return ONE search query per line, NOTHING else.
 """
 
 # ---------- Stage D  Code generation ----------

--- a/tests/test_part_lookup.py
+++ b/tests/test_part_lookup.py
@@ -1,0 +1,50 @@
+import asyncio
+import sys
+import pathlib
+import types
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Provide lightweight stubs for modules imported by part_lookup.
+prompts_stub = types.ModuleType("src.prompts")
+prompts_stub.PART_PROMPT = ""
+sys.modules["src.prompts"] = prompts_stub
+
+utils_stub = types.ModuleType("src.utils_llm")
+async def dummy_call_llm(model, text):
+    return text.split("\n", 1)[1]
+utils_stub.call_llm = dummy_call_llm
+utils_stub.LLM_PART = object()
+sys.modules["src.utils_llm"] = utils_stub
+
+import src.part_lookup as pl
+
+class DummyPart:
+    def __init__(self, lib, name, desc=""):
+        self.lib = lib
+        self.name = name
+        self.description = desc
+
+def test_extract_queries(monkeypatch):
+    plan = """header\nDraft search queries\nopamp low-noise dip-8\n^LM386$\n"""
+
+    async def fake_call_llm(model, text):
+        return text.split("\n", 1)[1]
+
+    monkeypatch.setattr(pl, "call_llm", fake_call_llm)
+    queries = asyncio.run(pl.extract_queries(plan))
+    assert queries == ["opamp low-noise dip-8", "^LM386$"]
+
+def test_lookup_parts_preserves_query(monkeypatch):
+    captured = []
+
+    def fake_search(q):
+        captured.append(q)
+        return [DummyPart("lib", "part", "desc")]
+
+    monkeypatch.setattr(pl, "search", fake_search)
+    results = pl.lookup_parts(["opamp (low-noise|dip-8)"])
+    assert captured == ["opamp (low-noise|dip-8)"]
+    assert results["opamp (low-noise|dip-8)"][0]["part"] == "lib:part"
+


### PR DESCRIPTION
## Summary
- support multi-term and regex queries when searching KiCad libraries
- let the planner and part cleaner prompts output full SKiDL search queries
- relax query validation and return part descriptions with ids
- update agent to use new extract_queries function
- document advanced search usage
- add unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68539e20fd0c8333842749cd584db89e