### PR TITLE
Fix env var docs and tokenizer fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,10 @@ MODEL_TEMP=0.15
 
 # MCP
 MCP_URL=http://localhost:8051/sse
+
+# Optional tuning parameters
+MAX_TOOL_CALLS=5
+TOKEN_MODEL=devstral-128k  # falls back to cl100k_base if unknown
+# Uses Tekken tokenizer from mistral-common when TOKEN_MODEL=devstral-128k
+MAX_CTX_TOK=40000
+SAFETY_MARGIN=2000

--- a/README.md
+++ b/README.md
@@ -6,3 +6,30 @@ Part selection now leverages SKiDL's full search syntax: queries may contain mul
 
 
 See [overview.md](overview.md) for detailed project goals and structure.
+
+## Setup
+
+Install dependencies with `pip install -r requirements.txt` then copy
+`.env.example` to `.env` and fill in the required values:
+
+```
+MISTRAL_API_KEY=<your API key>
+MISTRAL_API_BASE=https://api.mistral.ai/v1  # or your custom endpoint
+MODEL_PLAN=magistral-small-latest
+MODEL_PART=mistral-small-latest
+MODEL_CODE=devstral-small-latest
+MODEL_TEMP=0.15
+MCP_URL=http://localhost:8051/sse
+
+# Optional tuning variables
+MAX_TOOL_CALLS=5
+TOKEN_MODEL=devstral-128k  # falls back to cl100k_base if unknown
+MAX_CTX_TOK=40000
+SAFETY_MARGIN=2000
+```
+
+When `TOKEN_MODEL` is set to `devstral-128k`, the Tekken tokenizer shipped with
+`mistral-common` will be used automatically. Otherwise tiktoken's `cl100k_base`
+is used as a fallback.
+
+`MISTRAL_API_KEY`, `MODEL_PLAN`, `MODEL_PART`, `MODEL_CODE`, and `MCP_URL` must be provided. The others have sensible defaults.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ sseclient-py
 skidl>=2.0.1
 openai
 tiktoken
+mistral-common>=1.5.5
 
 # Node tool for SKiDL SVG export: npm install -g netlistsvg@1.0.2

--- a/src/agent.py
+++ b/src/agent.py
@@ -7,11 +7,18 @@ from .skidl_exec import run_skidl_script
 from .utils_llm import LLM_PLAN, call_llm
 from .utils_text import trim_to_tokens
 
+API_KEY = os.getenv("MISTRAL_API_KEY")
+if not API_KEY:
+    raise RuntimeError("MISTRAL_API_KEY environment variable not set")
+
 client = openai.AsyncOpenAI(
-    api_key=os.getenv("DEVSTRAL_API_KEY"),
-    base_url=os.getenv("DEVSTRAL_API_BASE", "https://api.openai.com/v1"),
+    api_key=API_KEY,
+    base_url=os.getenv("MISTRAL_API_BASE", "https://api.mistral.ai/v1"),
 )
+
 MODEL_CODE = os.getenv("MODEL_CODE")
+if not MODEL_CODE:
+    raise RuntimeError("MODEL_CODE environment variable not set")
 MODEL_TEMP = float(os.getenv("MODEL_TEMP", 0.15))
 
 # Maximum number of tool calls allowed per completion cycle to

--- a/src/utils_text.py
+++ b/src/utils_text.py
@@ -1,7 +1,26 @@
 import os
+from pathlib import Path
+
+try:
+    from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+    import mistral_common
+except Exception:
+    MistralTokenizer = None
+    mistral_common = None
 import tiktoken
 
-ENC = tiktoken.encoding_for_model(os.getenv("TOKEN_MODEL", "devstral-128k"))
+_token_model = os.getenv("TOKEN_MODEL", "devstral-128k")
+if _token_model == "devstral-128k" and MistralTokenizer and mistral_common:
+    try:
+        tekken_path = Path(os.path.dirname(mistral_common.__file__)) / "data" / "tekken_240911.json"
+        ENC = MistralTokenizer.from_file(str(tekken_path))
+    except Exception:
+        ENC = tiktoken.get_encoding("cl100k_base")
+else:
+    try:
+        ENC = tiktoken.encoding_for_model(_token_model)
+    except Exception:
+        ENC = tiktoken.get_encoding("cl100k_base")
 MAX_CTX_TOK = int(os.getenv("MAX_CTX_TOK", 40_000))
 SAFETY_MARGIN = int(os.getenv("SAFETY_MARGIN", 2_000))
 


### PR DESCRIPTION
## Summary
- use Tekken tokenizer from `mistral-common` when TOKEN_MODEL is `devstral-128k`
- validate required environment variables in agent
- mention dependency installation and tokenizer behavior in README
- document tokenizer behaviour in `.env.example`
- add `mistral-common` dependency

## Testing
- `pytest -q`
- `python -m src.main_cli` *(prompts for input)*

------
https://chatgpt.com/codex/tasks/task_e_6853c0c4bc9c8333b09cc047d1973b80