### PR TITLE
Fix: Add tool name and flush buffered assistant content for Mistral/OpenAI tool-calling compliance

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -136,8 +136,15 @@ async def pipeline(user_req: str):
             docs = await _retrieve_docs(
                 args.get("query", ""), args.get("match_count", 3)
             )
+            if content:
+                msgs.append({"role": "assistant", "content": content})
             msgs.append({"role": "assistant", "tool_calls": [call]})
-            msgs.append({"role": "tool", "tool_call_id": call["id"], "content": docs})
+            msgs.append({
+                "role": "tool",
+                "name": call["name"],
+                "tool_call_id": call["id"],
+                "content": docs,
+            })
             continue
         skidl_code = content
         break


### PR DESCRIPTION
## Summary
- fix tool calling compliance in agent pipeline

## Testing
- `pytest -q`
- `python -m src.agent` *(fails: MCP_URL environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_6855a8468f088333b76971e41669b5fd