### PR TITLE
Suppress SKiDL warnings for missing KiCad 6/7/8 env vars

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,21 @@
-"""Circuitron package."""
+"""Circuitron package.
+
+This module also configures SKiDL so that missing KiCad 6/7/8 environment
+variables don't generate noisy warnings when only KiCad 5 libraries are
+required.  If ``KICAD_SYMBOL_DIR`` is set, the same path is propagated to
+``KICAD6_SYMBOL_DIR``, ``KICAD7_SYMBOL_DIR`` and ``KICAD8_SYMBOL_DIR`` unless
+they are already defined.  Warnings about ``KICAD_SYMBOL_DIR`` itself are left
+untouched.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Propagate KiCad 5 symbol path to later versions if available to avoid
+# spurious warnings from SKiDL.
+_base = os.environ.get("KICAD_SYMBOL_DIR")
+if _base:
+    for _var in ("KICAD6_SYMBOL_DIR", "KICAD7_SYMBOL_DIR", "KICAD8_SYMBOL_DIR"):
+        os.environ.setdefault(_var, _base)
+

--- a/src/skidl_exec.py
+++ b/src/skidl_exec.py
@@ -1,4 +1,4 @@
-import tempfile, pathlib, subprocess, sys
+import tempfile, pathlib, subprocess, sys, os
 from typing import Dict, Union
 
 
@@ -7,7 +7,13 @@ def run_skidl_script(code: str) -> Dict[str, Union[pathlib.Path, str]]:
     py = tmp / "design.py"
     py.write_text(code)
 
-    subprocess.check_call([sys.executable, str(py)], cwd=tmp)
+    env = os.environ.copy()
+    base = env.get("KICAD_SYMBOL_DIR")
+    if base:
+        for var in ("KICAD6_SYMBOL_DIR", "KICAD7_SYMBOL_DIR", "KICAD8_SYMBOL_DIR"):
+            env.setdefault(var, base)
+
+    subprocess.check_call([sys.executable, str(py)], cwd=tmp, env=env)
 
     net = tmp / "circuit.net"
     svg = tmp / "schematic.svg"


### PR DESCRIPTION
## Summary
- propagate `KICAD_SYMBOL_DIR` to `KICAD6_SYMBOL_DIR`, `KICAD7_SYMBOL_DIR` and `KICAD8_SYMBOL_DIR`
- ensure subprocess execution also receives these env vars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c99830748333bdc953dd679e7284