### PR TITLE
Improve planner format & query parsing

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -2,9 +2,9 @@ import asyncio, json, os
 import openai
 from .prompts import PLAN_PROMPT, DOC_QA_PROMPT, SYSTEM_PROMPT, USER_TEMPLATE
 from .mcp_client import perform_rag_query, search_code_examples
-from .part_lookup import extract_queries, lookup_parts
-from .skidl_exec import run_skidl_script
-from .utils_llm import LLM_PLAN, call_llm
+from .plan_parser import split_plan
+from .part_lookup import lookup_parts
+from .utils_llm import LLM_PLAN, call_llm, extract_queries
 from .utils_text import trim_to_tokens
 
 API_KEY = os.getenv("MISTRAL_API_KEY")
@@ -68,7 +68,10 @@ async def _retrieve_docs(query: str, match_count=3):
 async def pipeline(user_req: str):
     # A ▸ PLAN
     plan = await call_llm(LLM_PLAN, PLAN_PROMPT.replace("REQUIREMENTS", user_req))
-    print("\n--- PLAN ---\n", plan)
+    internal, public = split_plan(plan)
+    print("\n--- PLAN ---\n", public)
+    # uncomment next line to debug-show reasoning:
+    # print("\n--- INTERNAL THINKING ---\n", internal)
     if input("\nApprove plan? [y/N] ").lower() != "y":
         print("Aborted.")
         return

--- a/src/plan_parser.py
+++ b/src/plan_parser.py
@@ -1,0 +1,27 @@
+import re
+
+HDR_RE = re.compile(r"^###\s+([A-Z_]+)", re.M)
+
+
+def split_plan(raw: str):
+    """Return (internal_blob, public_plan)."""
+    if "<INTERNAL>" in raw and "</INTERNAL>" in raw:
+        internal, public = raw.split("</INTERNAL>", 1)
+        internal = internal.split("<INTERNAL>", 1)[1].strip()
+        return internal, public.lstrip()
+    return "", raw
+
+
+def section(text: str, header: str) -> str:
+    """
+    Return the *last* block that starts with '### {header}' and ends at
+    the next header.  Assumes <INTERNAL> has been stripped already.
+    """
+    hdr = f"### {header}"
+    start = text.rfind(hdr)
+    if start == -1:
+        return ""
+    block = text[start + len(hdr):]
+    stop = HDR_RE.search(block)
+    return block[: stop.start() if stop else None].strip()
+

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -9,9 +9,17 @@ ROLE
 • Draft a technology-agnostic engineering plan for the user.
 • ALSO draft a SKiDL-aware implementation note block that later stages will consume.
 
-OUTPUT
-### SCHEMATIC_OVERVIEW      <-- clear for engineer approval
-- high-level functional blocks (bullet list)
+FORMAT
+# ❶  All free-form reasoning MUST live inside the tag pair <INTERNAL> … </INTERNAL>.
+# ❷  Outside <INTERNAL>, output each header shown below ONCE and in this order.
+# ❸  In DRAFT_SEARCH_QUERIES output *one query per line*, no brackets / quotes.
+
+<INTERNAL>
+(think step-by-step here; may repeat headers if you like)
+</INTERNAL>
+
+### SCHEMATIC_OVERVIEW
+- high-level functional blocks (one per line)
 
 ### CALCULATIONS
 - numbered list of design assumptions, equations, derivations
@@ -20,16 +28,16 @@ OUTPUT
 1. imperative, one per line
 2. …
 
-### DRAFT_SEARCH_QUERIES    <-- feeds part-lookup
-op-amp precision
-n-channel mosfet 60v
-…
+### DRAFT_SEARCH_QUERIES
+# one query per line (no quotes)
+op amp precision
+n channel mosfet 60v
 
-### PART_CANDIDATES         <-- optional free-text hints for lookup
+### PART_CANDIDATES
 - low-noise rail-to-rail op-amp, SOIC-8
 - 25 V, 10 µF X7R 0603 capacitor
 
-### IMPLEMENTATION_NOTES    <-- SKiDL-oriented; *not* shown to user
+### IMPLEMENTATION_NOTES
 - Each functional block will map to a Python function.
 - Instantiate power rails with drive = POWER.
 - …
@@ -37,19 +45,15 @@ n-channel mosfet 60v
 ### LIMITATIONS
 - bullet list of missing specs or open questions
 
-Do **NOT** output part numbers, footprints, library prefixes, or code blocks.
+HARD RULES
+• Do **NOT** output part numbers, footprints, library prefixes, or code blocks.
+• Outside <INTERNAL> you must not emit code fences or markdown.
 """
 
 # ---------- Stage B  Query cleaner ----------
 # Updated rules for unit normalisation and space handling
 PART_PROMPT = """You are **Circuitron-PartCleaner**.
-
-CLEAN the DRAFT_SEARCH_QUERIES:
-• lowercase
-• normalise units → keep number + unit letters (e.g. '10uF' → '10uf')
-• collapse multiple spaces
-• remove duplicates, preserve order
-Return ONLY a JSON array of strings.
+Return EXACTLY one JSON array of strings (no markdown fence, no prose).
 """
 
 # ---------- Stage D  Code generation ----------


### PR DESCRIPTION
## Summary
- update planner prompt to fence internal thoughts in `<INTERNAL>` tags and tighten rules
- create `plan_parser` helpers for splitting plans and extracting sections
- parse and deduplicate search queries with new helper in `utils_llm`
- guard `skidl.search()` against junk queries
- show only the public plan in the CLI
- adapt tests to new helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685682021b908333861704a32bf4037e