### PR TITLE
Fix SSE result parsing

### DIFF
--- a/src/mcp_client.py
+++ b/src/mcp_client.py
@@ -131,7 +131,12 @@ class _SSEClient:
 
         # Wait for response via SSE
         result = await fut
-        content = result.get("content") or result.get("results")
+        if isinstance(result, str):
+            try:
+                result = json.loads(result)
+            except json.JSONDecodeError:
+                result = {}
+        content = result.get("results") or result.get("content")
         if isinstance(content, list):
             return content
         return []


### PR DESCRIPTION
## Summary
- ensure `_SSEClient.call` handles JSON strings returned from the server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68570a7f6c5883339189de7da1e1bc02