### PR TITLE
Patch mcp_client initialization

### DIFF
--- a/src/mcp_client.py
+++ b/src/mcp_client.py
@@ -58,6 +58,14 @@ class _SSEClient:
         if self._message_url is None:
             raise RuntimeError("MCP server did not provide a session endpoint")
 
+        # ── automatic session initialization ──
+        # fire a tools/list RPC so the server marks the session "ready"
+        try:
+            await self.call("tools/list", {})
+        except Exception:
+            # if it fails, we’ll let your real calls bubble up later
+            pass
+
     # ------------------------------
     async def _listen(self) -> None:
         """Background task consuming SSE events from the server."""


### PR DESCRIPTION
## Summary
- auto-init Fast-MCP sessions with a `tools/list` call after SSE handshake

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857159971508333b1deca38ab76f423