### PR TITLE
Mitigate SSE startup race

### DIFF
--- a/src/mcp_client.py
+++ b/src/mcp_client.py
@@ -57,6 +57,8 @@ class _SSEClient:
         await self._endpoint_ready.wait()
         if self._message_url is None:
             raise RuntimeError("MCP server did not provide a session endpoint")
+        # Avoid race: give the MCP server a moment to finish its lifespan init
+        await asyncio.sleep(0.5)
 
 
     # ------------------------------


### PR DESCRIPTION
## Summary
- fix race condition with SSE connect that caused requests before MCP initialization

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68571f265c3883339b6be5b7ee58e7eb