### PR TITLE
Add PlanEditor feedback flow

### DIFF
--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -1,0 +1,82 @@
+"""Circuitron orchestration pipeline."""
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from agents import Runner
+
+from development.agents import planner, plan_editor
+from agents.result import RunResult
+from development.models import PlanOutput, UserFeedback, PlanEditorOutput
+from development.utils import (
+    pretty_print_plan,
+    pretty_print_edited_plan,
+    pretty_print_regeneration_prompt,
+    extract_reasoning_summary,
+    collect_user_feedback,
+    format_plan_edit_input,
+)
+
+
+async def run_planner(prompt: str) -> RunResult:
+    """Run the planning agent and return the run result."""
+    return await Runner.run(planner, prompt)
+
+
+async def run_plan_editor(
+    original_prompt: str, plan: PlanOutput, feedback: UserFeedback
+) -> PlanEditorOutput:
+    """Run the PlanEditor agent with formatted input."""
+    input_msg = format_plan_edit_input(original_prompt, plan, feedback)
+    result = await Runner.run(plan_editor, input_msg)
+    return result.final_output
+
+
+async def pipeline(prompt: str, show_reasoning: bool = False, debug: bool = False) -> PlanOutput:
+    """Execute planning and optional plan editing flow."""
+    plan_result = await run_planner(prompt)
+    plan = plan_result.final_output
+    pretty_print_plan(plan)
+
+    if debug and plan.calculation_codes:
+        print("\n=== Debug: Calculation Codes ===")
+        for i, code in enumerate(plan.calculation_codes, 1):
+            print(f"\nCalculation #{i} code:\n{code}")
+
+    if show_reasoning:
+        print("\n=== Reasoning Summary ===\n")
+        print(extract_reasoning_summary(plan_result))
+
+    feedback = collect_user_feedback(plan)
+    if not any([
+        feedback.open_question_answers,
+        feedback.requested_edits,
+        feedback.additional_requirements,
+    ]):
+        return plan
+
+    edit_result = await run_plan_editor(prompt, plan, feedback)
+
+    if edit_result.decision.action == "edit_plan":
+        pretty_print_edited_plan(edit_result)
+        return edit_result.updated_plan  # type: ignore[return-value]
+
+    pretty_print_regeneration_prompt(edit_result)
+    assert edit_result.reconstructed_prompt is not None
+    regen_result = await run_planner(edit_result.reconstructed_prompt)
+    new_plan = regen_result.final_output
+    pretty_print_plan(new_plan)
+    return new_plan
+
+
+async def main() -> None:
+    """CLI entry point for the Circuitron pipeline."""
+    prompt = sys.argv[1] if len(sys.argv) > 1 else input("Prompt: ")
+    show_reasoning = "--reasoning" in sys.argv or "-r" in sys.argv
+    debug = "--debug" in sys.argv or "-d" in sys.argv
+    await pipeline(prompt, show_reasoning=show_reasoning, debug=debug)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/development/agents.py
+++ b/development/agents.py
@@ -6,19 +6,13 @@ Contains all specialized agents used in the PCB design pipeline.
 from agents import Agent
 from agents.model_settings import ModelSettings
 from .prompts import PLAN_PROMPT, PLAN_EDIT_PROMPT
-from .models import PlanOutput, EditedPlanOutput, RegeneratedPlanPrompt
+from .models import PlanOutput, PlanEditorOutput
 from .tools import execute_calculation
 
 
 def create_planning_agent() -> Agent:
     """Create and configure the Planning Agent."""
-    model_settings = ModelSettings(
-        tool_choice="required",
-        reasoning={
-            "effort": "medium",  # default
-            "summary": "detailed"  
-        }
-    )
+    model_settings = ModelSettings(tool_choice="required")
 
     return Agent(
         name="Circuitron-Planner",
@@ -32,22 +26,15 @@ def create_planning_agent() -> Agent:
 
 def create_plan_edit_agent() -> Agent:
     """Create and configure the Plan Edit Agent."""
-    model_settings = ModelSettings(
-        tool_choice="required",
-        reasoning={
-            "effort": "medium",
-            "summary": "detailed"  
-        }
-    )
+    model_settings = ModelSettings(tool_choice="required")
 
     return Agent(
         name="Circuitron-PlanEditor",
         instructions=PLAN_EDIT_PROMPT,
         model="o4-mini",
-        # Note: We'll need to handle dynamic output types based on the decision
-        # This will be handled in the orchestration logic
+        output_type=PlanEditorOutput,
         tools=[execute_calculation],
-        model_settings=model_settings
+        model_settings=model_settings,
     )
 
 

--- a/development/utils.py
+++ b/development/utils.py
@@ -5,7 +5,7 @@ Contains formatting, printing, and other helper utilities.
 
 from typing import List
 from agents.items import ReasoningItem
-from .models import PlanOutput, UserFeedback, EditedPlanOutput, RegeneratedPlanPrompt
+from .models import PlanOutput, UserFeedback, PlanEditorOutput
 
 
 def extract_reasoning_summary(run_result):
@@ -128,7 +128,7 @@ def crawl_documentation(base_url: str, doc_urls: List[str], output_file: str) ->
             if crawl_results:
                 current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 combined_content = [
-                    f"# Documentation",
+                    "# Documentation",
                     f"**Crawled from:** {base_url}",
                     f"**Generated on:** {current_time}",
                     f"**Total pages:** {len(crawl_results)}",
@@ -178,12 +178,12 @@ def collect_user_feedback(plan: PlanOutput) -> UserFeedback:
         
         for i, question in enumerate(plan.design_limitations, 1):
             print(f"\n{i}. {question}")
-            answer = input(f"   Your answer: ").strip()
+            answer = input("   Your answer: ").strip()
             if answer:
                 feedback.open_question_answers.append(f"Q{i}: {question}\nA: {answer}")
     
     # Collect general edits and modifications
-    print(f"\n" + "-" * 50)
+    print("\n" + "-" * 50)
     print("OPTIONAL EDITS & MODIFICATIONS")
     print("-" * 50)
     print("Do you have any specific changes, clarifications, or modifications to request?")
@@ -198,7 +198,7 @@ def collect_user_feedback(plan: PlanOutput) -> UserFeedback:
         edit_counter += 1
     
     # Collect additional requirements
-    print(f"\n" + "-" * 50)
+    print("\n" + "-" * 50)
     print("ADDITIONAL REQUIREMENTS")
     print("-" * 50)
     print("Are there any new requirements or constraints not captured in the original design?")
@@ -324,7 +324,7 @@ def format_plan_edit_input(original_prompt: str, plan: PlanOutput, feedback: Use
     return "\n".join(input_parts)
 
 
-def pretty_print_edited_plan(edited_output: EditedPlanOutput):
+def pretty_print_edited_plan(edited_output: PlanEditorOutput):
     """Pretty print an edited plan output with change summary."""
     print("\n" + "="*60)
     print("PLAN SUCCESSFULLY UPDATED")
@@ -334,35 +334,36 @@ def pretty_print_edited_plan(edited_output: EditedPlanOutput):
     print(f"Reasoning: {edited_output.decision.reasoning}")
     
     if edited_output.changes_summary:
-        print(f"\n" + "="*40)
+        print("\n" + "=" * 40)
         print("SUMMARY OF CHANGES")
         print("="*40)
         for i, change in enumerate(edited_output.changes_summary, 1):
             print(f"{i}. {change}")
     
-    print(f"\n" + "="*40)
+    print("\n" + "=" * 40)
     print("UPDATED DESIGN PLAN")
     print("="*40)
-    pretty_print_plan(edited_output.updated_plan)
+    if edited_output.updated_plan:
+        pretty_print_plan(edited_output.updated_plan)
 
 
-def pretty_print_regeneration_prompt(regen_output: RegeneratedPlanPrompt):
+def pretty_print_regeneration_prompt(regen_output: PlanEditorOutput):
     """Pretty print a regeneration prompt output."""
     print("\n" + "="*60)
     print("PLAN REGENERATION REQUIRED")
-    print("="*60)
+    print("=" * 60)
     
     print(f"\nAction: {regen_output.decision.action}")
     print(f"Reasoning: {regen_output.decision.reasoning}")
     
     if regen_output.regeneration_guidance:
-        print(f"\n" + "="*40)
+        print("\n" + "=" * 40)
         print("REGENERATION GUIDANCE")
         print("="*40)
         for i, guidance in enumerate(regen_output.regeneration_guidance, 1):
             print(f"{i}. {guidance}")
     
-    print(f"\n" + "="*40)
+    print("\n" + "=" * 40)
     print("RECONSTRUCTED PROMPT")
     print("="*40)
     print(regen_output.reconstructed_prompt)

--- a/tests/test_format_input.py
+++ b/tests/test_format_input.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from development.models import PlanOutput, UserFeedback
+from development.utils import format_plan_edit_input
+
+
+def test_format_plan_edit_input_includes_sections():
+    plan = PlanOutput(
+        design_rationale=["Reason"],
+        functional_blocks=["Block"],
+        implementation_actions=["Do"],
+        component_search_queries=["resistor"],
+        implementation_notes=["note"],
+        design_limitations=["open"],
+    )
+    feedback = UserFeedback(
+        open_question_answers=["A"],
+        requested_edits=["edit"],
+    )
+    text = format_plan_edit_input("prompt", plan, feedback)
+    assert "PLAN EDITING REQUEST" in text
+    assert "Functional Blocks:" in text
+    assert "Requested Edits:" in text
+    assert "Answers to Open Questions:" in text

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from development.models import PlanOutput, PlanEditDecision, PlanEditorOutput
+
+
+def test_plan_editor_output_edit():
+    plan = PlanOutput()
+    decision = PlanEditDecision(action="edit_plan", reasoning="ok")
+    result = PlanEditorOutput(decision=decision, updated_plan=plan)
+    assert result.updated_plan is plan
+
+
+def test_plan_editor_output_edit_missing_plan():
+    decision = PlanEditDecision(action="edit_plan", reasoning="bad")
+    with pytest.raises(ValueError):
+        PlanEditorOutput(decision=decision)
+
+
+def test_plan_editor_output_regenerate():
+    decision = PlanEditDecision(action="regenerate_plan", reasoning="redo")
+    result = PlanEditorOutput(decision=decision, reconstructed_prompt="new")
+    assert result.reconstructed_prompt == "new"


### PR DESCRIPTION
## Summary
- implement new `circuitron.pipeline` with planner and plan editor stages
- unify plan editor models into `PlanEditorOutput`
- update agents and utils for plan editing
- add unit tests for plan editor models and formatting helpers
- fix RunResult import

## Testing
- `ruff check circuitron/pipeline.py development/models.py development/utils.py development/agents.py`
- `mypy --ignore-missing-imports circuitron/pipeline.py development/models.py development/utils.py development/agents.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685efef0f3b8833399e663b36440942d