### PR TITLE
Enable automatic agent handoffs

### DIFF
--- a/development/agents.py
+++ b/development/agents.py
@@ -3,7 +3,7 @@ Agent definitions and configurations for the Circuitron system.
 Contains all specialized agents used in the PCB design pipeline.
 """
 
-from agents import Agent
+from agents import Agent, handoff
 from agents.model_settings import ModelSettings
 from .prompts import PLAN_PROMPT, PLAN_EDIT_PROMPT, PARTFINDER_PROMPT
 from .models import PlanOutput, PlanEditorOutput, PartFinderOutput
@@ -55,3 +55,7 @@ def create_partfinder_agent() -> Agent:
 planner = create_planning_agent()
 plan_editor = create_plan_edit_agent()
 part_finder = create_partfinder_agent()
+
+# Configure handoffs between agents
+planner.handoffs = [plan_editor]
+plan_editor.handoffs = [handoff(planner), handoff(part_finder)]

--- a/development/main.py
+++ b/development/main.py
@@ -7,47 +7,14 @@ import sys
 import asyncio
 from agents import Runner
 from .config import setup_environment
-from .agents import planner, plan_editor, part_finder
-from .utils import (
-    pretty_print_plan,
-    pretty_print_edited_plan,
-    pretty_print_regeneration_prompt,
-    collect_user_feedback,
-    format_plan_edit_input,
-)
-from .models import UserFeedback, PlanEditorOutput, PartFinderOutput
+from .agents import planner
+from .models import PartFinderOutput
 
 
-async def run_circuitron(prompt: str):
-    """Execute the full Circuitron pipeline."""
-    plan_result = await Runner.run(planner, prompt)
-    plan = plan_result.final_output
-    pretty_print_plan(plan)
-
-    feedback = collect_user_feedback(plan)
-    if any([
-        feedback.open_question_answers,
-        feedback.requested_edits,
-        feedback.additional_requirements,
-    ]):
-        edit_input = format_plan_edit_input(prompt, plan, feedback)
-        edit_result = await Runner.run(plan_editor, edit_input)
-        edit_output = edit_result.final_output_as(PlanEditorOutput)
-        if edit_output.decision.action == "regenerate_plan":
-            assert edit_output.reconstructed_prompt is not None
-            pretty_print_regeneration_prompt(edit_output)
-            regen_result = await Runner.run(planner, edit_output.reconstructed_prompt)
-            plan = regen_result.final_output
-        else:
-            pretty_print_edited_plan(edit_output)
-            plan = edit_output.updated_plan or plan
-
-    if plan.component_search_queries:
-        search_input = "\n".join(plan.component_search_queries)
-        part_result = await Runner.run(part_finder, search_input)
-        return part_result.final_output_as(PartFinderOutput)
-
-    return None
+async def run_circuitron(prompt: str) -> PartFinderOutput | None:
+    """Execute the Circuitron workflow via agent handoffs."""
+    result = await Runner.run(planner, prompt)
+    return result.final_output_as(PartFinderOutput)
 
 
 def main():

--- a/development/prompts.py
+++ b/development/prompts.py
@@ -1,10 +1,10 @@
-"""
-Agent prompts and instructions for the Circuitron system.
-Contains all the specialized prompts for different agents.
-"""
+"""Agent prompts for the Circuitron system."""
+
+from agents.extensions.handoff_prompt import RECOMMENDED_PROMPT_PREFIX
 
 # ---------- Planning Agent Prompt ----------
-PLAN_PROMPT = """You are Circuitron-Planner, an expert PCB designer.
+PLAN_PROMPT = f"""{RECOMMENDED_PROMPT_PREFIX}
+You are Circuitron-Planner, an expert PCB designer.
 
 Analyze the user's requirements and create a comprehensive design solution.
 Before everything, provide a concise **Design Rationale** that explains your overarching goals, trade-offs, and key performance targets in plain English.
@@ -33,7 +33,8 @@ Focus on creating a complete, actionable plan that later agents can execute. **W
 """
 
 # ---------- Plan Edit Agent Prompt ----------
-PLAN_EDIT_PROMPT = """You are Circuitron-PlanEditor, an expert PCB design reviewer and plan editor.
+PLAN_EDIT_PROMPT = f"""{RECOMMENDED_PROMPT_PREFIX}
+You are Circuitron-PlanEditor, an expert PCB design reviewer and plan editor.
 
 Your role is to intelligently process user feedback on design plans and determine the appropriate course of action:
 1. **Minor/Moderate Edits**: Apply user-requested changes directly to the existing plan
@@ -97,7 +98,7 @@ Your role is to intelligently process user feedback on design plans and determin
 Focus on maintaining the professional engineering workflow while seamlessly incorporating user expertise and preferences."""
 
 # ---------- Part Search Agent Prompt ----------
-PART_SEARCH_PROMPT = """
+PART_SEARCH_PROMPT = f"""{RECOMMENDED_PROMPT_PREFIX}
 You are Circuitron-PartFinder, an expert in SKiDL component searches.
 
 Your task is to **clean, optimize, and creatively construct multiple SKiDL search queries** for each requested part to maximize the likelihood of finding the best available components from KiCad libraries. You are not limited to a single query: use multiple approaches in sequence, from broad to highly specific, and exploit all SKiDL search features as shown in the official documentation.


### PR DESCRIPTION
## Summary
- prepend recommended handoff prefix to all agent prompts
- wire planner -> plan editor -> part finder handoffs
- simplify development entrypoint to rely on SDK handoffs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa21284dc83339a2a572919b963fd