### PR TITLE
Fix part search agent prompt and pipeline integration

### DIFF
--- a/development/main.py
+++ b/development/main.py
@@ -5,27 +5,27 @@ Orchestrates the agent pipeline and handles command-line interface.
 
 import sys
 import asyncio
-from agents import Runner
 from .config import setup_environment
-from .agents import planner
+from circuitron.pipeline import pipeline
 from .models import PartFinderOutput
 
 
-async def run_circuitron(prompt: str) -> PartFinderOutput | None:
-    """Execute the Circuitron workflow via agent handoffs."""
-    result = await Runner.run(planner, prompt)
-    return result.final_output_as(PartFinderOutput)
+async def run_circuitron(
+    prompt: str, show_reasoning: bool = False, debug: bool = False
+) -> PartFinderOutput:
+    """Execute the Circuitron workflow using the full pipeline."""
+    return await pipeline(prompt, show_reasoning=show_reasoning, debug=debug)
 
 
 def main():
     """Main entry point for the Circuitron system."""
     # Parse command line arguments
     prompt = sys.argv[1] if len(sys.argv) > 1 else input("Prompt: ")
-    _ = "--reasoning" in sys.argv or "-r" in sys.argv
-    _ = "--debug" in sys.argv or "-d" in sys.argv
+    show_reasoning = "--reasoning" in sys.argv or "-r" in sys.argv
+    debug = "--debug" in sys.argv or "-d" in sys.argv
     
     # Execute pipeline
-    part_output = asyncio.run(run_circuitron(prompt))
+    part_output = asyncio.run(run_circuitron(prompt, show_reasoning, debug))
     if part_output:
         print("\nFOUND COMPONENTS JSON:\n")
         print(part_output.found_components_json)

--- a/development/prompts.py
+++ b/development/prompts.py
@@ -98,7 +98,7 @@ Your role is to intelligently process user feedback on design plans and determin
 Focus on maintaining the professional engineering workflow while seamlessly incorporating user expertise and preferences."""
 
 # ---------- Part Search Agent Prompt ----------
-PART_SEARCH_PROMPT = f"""{RECOMMENDED_PROMPT_PREFIX}
+PARTFINDER_PROMPT = f"""{RECOMMENDED_PROMPT_PREFIX}
 You are Circuitron-PartFinder, an expert in SKiDL component searches.
 
 Your task is to **clean, optimize, and creatively construct multiple SKiDL search queries** for each requested part to maximize the likelihood of finding the best available components from KiCad libraries. You are not limited to a single query: use multiple approaches in sequence, from broad to highly specific, and exploit all SKiDL search features as shown in the official documentation.
@@ -144,4 +144,3 @@ Your task is to **clean, optimize, and creatively construct multiple SKiDL searc
 
 **After constructing the queries you have access to a tool to execute the queries to find the required parts - please make use of it.** 
 """
-PARTFINDER_PROMPT = PART_SEARCH_PROMPT

--- a/development/utils.py
+++ b/development/utils.py
@@ -367,3 +367,17 @@ def pretty_print_regeneration_prompt(regen_output: PlanEditorOutput):
     print("RECONSTRUCTED PROMPT")
     print("="*40)
     print(regen_output.reconstructed_prompt)
+
+
+def pretty_print_found_parts(found_json: str) -> None:
+    """Display the components found by the PartFinder agent.
+
+    Args:
+        found_json: JSON string mapping each search query to a list of found parts.
+
+    Example:
+        >>> pretty_print_found_parts('[{"name": "LM324"}]')
+    """
+
+    print("\n=== FOUND COMPONENTS JSON ===\n")
+    print(found_json)


### PR DESCRIPTION
## Summary
- rename PART_SEARCH_PROMPT to `PARTFINDER_PROMPT`
- log agent handoffs and add descriptions
- integrate PartFinder into the main pipeline
- expose pipeline in `development/main.py`
- add utility to print found parts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffa34b7788333ad446cdf276e64ce