### PR TITLE
Implement configuration module, argparse CLI, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ MCP_URL=http://localhost:8051
 
 ```
 
-`OPENAI_API_KEY`, `MODEL_PLAN`, `MODEL_PART`, `MODEL_CODE`, and `MCP_URL` must be provided. The others have sensible defaults.
+Required variables:
+`OPENAI_API_KEY`, `PLANNING_MODEL`, `PLAN_EDIT_MODEL`, `PART_FINDER_MODEL`, and `MCP_URL`.
+Optional overrides:
+`CALC_IMAGE` and `KICAD_IMAGE` for custom Docker images.
 
 ## Tech Stack
 

--- a/development/agents.py
+++ b/development/agents.py
@@ -3,9 +3,11 @@ Agent definitions and configurations for the Circuitron system.
 Contains all specialized agents used in the PCB design pipeline.
 """
 
-from agents import Agent, handoff, RunContextWrapper
+from agents import Agent, RunContextWrapper, handoff
 from agents.model_settings import ModelSettings
 import logging
+
+from .config import settings
 from .prompts import PLAN_PROMPT, PLAN_EDIT_PROMPT, PARTFINDER_PROMPT
 from .models import PlanOutput, PlanEditorOutput, PartFinderOutput
 from .tools import execute_calculation, search_kicad_libraries
@@ -18,7 +20,7 @@ def create_planning_agent() -> Agent:
     return Agent(
         name="Circuitron-Planner",
         instructions=PLAN_PROMPT,
-        model="o4-mini",
+        model=settings.planning_model,
         output_type=PlanOutput,
         tools=[execute_calculation],
         model_settings=model_settings,
@@ -33,7 +35,7 @@ def create_plan_edit_agent() -> Agent:
     return Agent(
         name="Circuitron-PlanEditor",
         instructions=PLAN_EDIT_PROMPT,
-        model="o4-mini",
+        model=settings.plan_edit_model,
         output_type=PlanEditorOutput,
         tools=[execute_calculation],
         model_settings=model_settings,
@@ -48,7 +50,7 @@ def create_partfinder_agent() -> Agent:
     return Agent(
         name="Circuitron-PartFinder",
         instructions=PARTFINDER_PROMPT,
-        model="o4-mini",
+        model=settings.part_finder_model,
         output_type=PartFinderOutput,
         tools=[search_kicad_libraries],
         model_settings=model_settings,

--- a/development/config.py
+++ b/development/config.py
@@ -1,16 +1,24 @@
-"""
-Configuration and setup for the Circuitron system.
-Handles environment variables, logging, and tracing configuration.
-"""
+"""Environment setup and global configuration for Circuitron."""
+
+from __future__ import annotations
 
 import logfire
 from dotenv import load_dotenv
 
-def setup_environment():
+from .settings import Settings
+
+settings: Settings
+
+
+def setup_environment() -> None:
     """Initialize environment variables and configure logging/tracing."""
     load_dotenv()
     logfire.configure()
     logfire.instrument_openai_agents()
+
+    global settings
+    settings = Settings()
+
 
 # Initialize when module is imported
 setup_environment()

--- a/development/main.py
+++ b/development/main.py
@@ -3,10 +3,9 @@ Main entry point for the Circuitron development system.
 Orchestrates the agent pipeline and handles command-line interface.
 """
 
-import sys
 import asyncio
 from .config import setup_environment
-from circuitron.pipeline import pipeline
+from circuitron.pipeline import pipeline, parse_args
 from .models import PartFinderOutput
 
 
@@ -19,10 +18,10 @@ async def run_circuitron(
 
 def main():
     """Main entry point for the Circuitron system."""
-    # Parse command line arguments
-    prompt = sys.argv[1] if len(sys.argv) > 1 else input("Prompt: ")
-    show_reasoning = "--reasoning" in sys.argv or "-r" in sys.argv
-    debug = "--debug" in sys.argv or "-d" in sys.argv
+    args = parse_args()
+    prompt = args.prompt or input("Prompt: ")
+    show_reasoning = args.reasoning
+    debug = args.debug
     
     # Execute pipeline
     part_output = asyncio.run(run_circuitron(prompt, show_reasoning, debug))

--- a/development/settings.py
+++ b/development/settings.py
@@ -1,0 +1,24 @@
+"""Centralized configuration values for Circuitron.
+
+Environment variables can override defaults.
+
+Example:
+    from development.config import settings
+    print(settings.planning_model)
+"""
+
+from dataclasses import dataclass
+import os
+
+
+@dataclass
+class Settings:
+    """Configuration settings loaded from environment variables."""
+
+    planning_model: str = os.getenv("PLANNING_MODEL", "o4-mini")
+    plan_edit_model: str = os.getenv("PLAN_EDIT_MODEL", "o4-mini")
+    part_finder_model: str = os.getenv("PART_FINDER_MODEL", "o4-mini")
+    calculation_image: str = os.getenv("CALC_IMAGE", "python:3.12-slim")
+    kicad_image: str = os.getenv(
+        "KICAD_IMAGE", "ghcr.io/circuitron/kicad-skidl:latest"
+    )

--- a/development/utils.py
+++ b/development/utils.py
@@ -5,13 +5,15 @@ Contains formatting, printing, and other helper utilities.
 
 from typing import List
 from agents.items import ReasoningItem
+from agents.result import RunResult
 from .models import PlanOutput, UserFeedback, PlanEditorOutput
 
 
-def extract_reasoning_summary(run_result):
-    """
-    Return the concatenated model‐generated reasoning summary text
-    from ResponseReasoningItem.raw_item.summary entries.
+def extract_reasoning_summary(run_result: RunResult) -> str:
+    """Return the reasoning summary from a run result.
+
+    Example:
+        >>> summary = extract_reasoning_summary(result)
     """
     texts = []
     for item in run_result.new_items:
@@ -71,93 +73,6 @@ def pretty_print_plan(plan: PlanOutput):
     
     print()  # trailing newline
 
-
-def crawl_documentation(base_url: str, doc_urls: List[str], output_file: str) -> bool:
-    """
-    Crawl documentation from a list of URLs and save as a single markdown file.
-    
-    This function uses crawl4ai to fetch content from multiple documentation pages
-    and combines them into a comprehensive markdown document.
-    
-    Args:
-        base_url: The base URL of the documentation site
-        doc_urls: List of specific documentation URLs to crawl
-        output_file: Path to the output markdown file
-        
-    Returns:
-        bool: True if successful, False otherwise
-        
-    Example:
-        urls = [
-            "https://example.com/docs/",
-            "https://example.com/docs/quickstart/",
-            "https://example.com/docs/api/"
-        ]
-        success = crawl_documentation(
-            "https://example.com/docs/", 
-            urls, 
-            "example_docs.md"
-        )
-    """
-    try:
-        import asyncio
-        from crawl4ai import AsyncWebCrawler
-        from crawl4ai.async_configs import BrowserConfig, CrawlerRunConfig, CacheMode
-        from datetime import datetime
-        
-        async def _crawl():
-            browser_config = BrowserConfig(headless=True, verbose=False)
-            run_config = CrawlerRunConfig(
-                cache_mode=CacheMode.BYPASS,
-                word_count_threshold=10,
-                exclude_external_links=True,
-                remove_overlay_elements=True,
-                process_iframes=True
-            )
-            
-            crawl_results = []
-            async with AsyncWebCrawler(config=browser_config) as crawler:
-                for url in doc_urls:
-                    try:
-                        result = await crawler.arun(url, config=run_config)
-                        crawl_results.append(result)
-                    except Exception as e:
-                        print(f"Failed to crawl {url}: {e}")
-                        
-            # Save combined markdown
-            if crawl_results:
-                current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                combined_content = [
-                    "# Documentation",
-                    f"**Crawled from:** {base_url}",
-                    f"**Generated on:** {current_time}",
-                    f"**Total pages:** {len(crawl_results)}",
-                    "", "---", ""
-                ]
-                
-                for i, result in enumerate(crawl_results, 1):
-                    if result.success:
-                        combined_content.extend([
-                            f"## Page {i}",
-                            f"**Source URL:** {result.url}",
-                            "---",
-                            str(result.markdown),
-                            "", "---", ""
-                        ])
-                
-                with open(output_file, 'w', encoding='utf-8') as f:
-                    f.write('\n'.join(combined_content))
-                return True
-            return False
-        
-        return asyncio.run(_crawl())
-        
-    except ImportError:
-        print("crawl4ai not installed. Install with: pip install crawl4ai")
-        return False
-    except Exception as e:
-        print(f"Error crawling documentation: {e}")
-        return False
 
 
 def collect_user_feedback(plan: PlanOutput) -> UserFeedback:

--- a/overview.md
+++ b/overview.md
@@ -116,4 +116,10 @@ The tool acts as a productivity booster: it provides a high-quality, logically c
 
 - [SKiDL Documentation](https://devbisme.github.io/skidl/)
 - [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/)
+
+### Configuration
+
+Runtime models and Docker images are configured via environment variables read
+by ``development.settings``. See ``README.md`` for details on the available
+variables.
 ---

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,16 @@
+import importlib
+import os
+
+
+def test_agent_models_from_env(monkeypatch):
+    import sys
+    sys.modules.pop("development.agents", None)
+    import development.config as cfg
+    cfg.settings.planning_model = "x-model"
+    cfg.settings.plan_edit_model = "y-model"
+    cfg.settings.part_finder_model = "z-model"
+    mod = importlib.import_module("development.agents")
+    assert mod.planner.model == "x-model"
+    assert mod.plan_editor.model == "y-model"
+    assert mod.part_finder.model == "z-model"
+

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,46 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from development.models import PlanOutput, PlanEditDecision, PlanEditorOutput, UserFeedback, PartFinderOutput
+from circuitron import pipeline as pl
+
+
+async def fake_pipeline_no_feedback():
+    plan = PlanOutput(component_search_queries=["R"], calculation_codes=[])
+    plan_result = SimpleNamespace(final_output=plan, new_items=[])
+    part_out = PartFinderOutput(found_components_json="[]")
+    with patch.object(pl, "run_planner", AsyncMock(return_value=plan_result)), \
+         patch.object(pl, "run_part_finder", AsyncMock(return_value=part_out)), \
+         patch.object(pl, "collect_user_feedback", return_value=UserFeedback()):
+        result = await pl.pipeline("test")
+    assert result is part_out
+
+
+async def fake_pipeline_edit_plan():
+    plan = PlanOutput(component_search_queries=["R"], calculation_codes=[])
+    plan_result = SimpleNamespace(final_output=plan, new_items=[])
+    edited_plan = PlanOutput(component_search_queries=["C"])
+    edit_output = PlanEditorOutput(
+        decision=PlanEditDecision(action="edit_plan", reasoning="ok"),
+        updated_plan=edited_plan,
+    )
+    part_out = PartFinderOutput(found_components_json="[]")
+    with patch.object(pl, "run_planner", AsyncMock(return_value=plan_result)), \
+         patch.object(pl, "collect_user_feedback", return_value=UserFeedback(requested_edits=["x"])), \
+         patch.object(pl, "run_plan_editor", AsyncMock(return_value=edit_output)), \
+         patch.object(pl, "run_part_finder", AsyncMock(return_value=part_out)):
+        result = await pl.pipeline("test")
+    assert result is part_out
+
+
+def test_pipeline_asyncio():
+    asyncio.run(fake_pipeline_no_feedback())
+    asyncio.run(fake_pipeline_edit_plan())
+
+
+def test_parse_args():
+    args = pl.parse_args(["prompt", "-r", "-d"])
+    assert args.prompt == "prompt"
+    assert args.reasoning is True
+    assert args.debug is True

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -17,3 +17,14 @@ def test_search_kicad_libraries():
         data = json.loads(result)
         assert data[0]["name"] == "LM324"
         run_mock.assert_called_once()
+
+
+def test_search_kicad_libraries_timeout():
+    with patch(
+        "development.tools.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
+    ):
+        ctx = RunContextWrapper(context=None)
+        args = json.dumps({"query": "123"})
+        result = asyncio.run(search_kicad_libraries.on_invoke_tool(ctx, args))
+        assert "error" in result.lower()


### PR DESCRIPTION
## Summary
- centralize runtime settings in new `development.settings` module
- use settings in agents and tools instead of hard-coded strings
- improve error handling and CLI parsing in `circuitron.pipeline`
- refactor `development.main` to share argparse parser
- remove unused utils, add type hints and docstrings
- document new environment variables
- add unit tests for pipeline, agents, and tool error paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601cda67c08333a8ddf1ec90b47b36