### PR TITLE
Implement footprint search in PartFinder agent

### DIFF
--- a/circuitron/agents.py
+++ b/circuitron/agents.py
@@ -10,7 +10,7 @@ import logging
 from .config import settings
 from .prompts import PLAN_PROMPT, PLAN_EDIT_PROMPT, PARTFINDER_PROMPT
 from .models import PlanOutput, PlanEditorOutput, PartFinderOutput
-from .tools import execute_calculation, search_kicad_libraries
+from .tools import execute_calculation, search_kicad_libraries, search_kicad_footprints
 
 
 def create_planning_agent() -> Agent:
@@ -52,7 +52,7 @@ def create_partfinder_agent() -> Agent:
         instructions=PARTFINDER_PROMPT,
         model=settings.part_finder_model,
         output_type=PartFinderOutput,
-        tools=[search_kicad_libraries],
+        tools=[search_kicad_libraries, search_kicad_footprints],
         model_settings=model_settings,
         handoff_description="Search KiCad libraries for required parts",
     )

--- a/circuitron/models.py
+++ b/circuitron/models.py
@@ -143,6 +143,15 @@ class FoundPart(BaseModel):
     description: str | None = None
 
 
+class FoundFootprint(BaseModel):
+    """Structure for a footprint found in KiCad libraries."""
+
+    name: str
+    library: str
+    description: str | None = None
+    package_type: str | None = None
+
+
 class PartFinderOutput(BaseModel):
     """Output from the PartFinder agent."""
     model_config = ConfigDict(extra="forbid", strict=True)

--- a/circuitron/prompts.py
+++ b/circuitron/prompts.py
@@ -99,9 +99,17 @@ Focus on maintaining the professional engineering workflow while seamlessly inco
 
 # ---------- Part Search Agent Prompt ----------
 PARTFINDER_PROMPT = f"""{RECOMMENDED_PROMPT_PREFIX}
-You are Circuitron-PartFinder, an expert in SKiDL component searches.
+You are Circuitron-PartFinder, an expert in SKiDL component and footprint searches.
 
-Your task is to **clean, optimize, and creatively construct multiple SKiDL search queries** for each requested part to maximize the likelihood of finding the best available components from KiCad libraries. You are not limited to a single query: use multiple approaches in sequence, from broad to highly specific, and exploit all SKiDL search features as shown in the official documentation.
+Your task is to **clean, optimize, and creatively construct multiple SKiDL search queries** for each requested part to maximize the likelihood of finding the best available components and footprints from KiCad libraries. You are not limited to a single query: use multiple approaches in sequence, from broad to highly specific, and exploit all SKiDL search features as shown in the official documentation.
+
+You must **find both symbols AND footprints** for each requested component. Use `search()` for component symbols and `search_footprints()` for packaging options.
+
+**Search Strategy:**
+For each component:
+- Start with symbol search to find the electronic part.
+- Follow with footprint search to list suitable packages.
+- Prioritize footprints matching any specified package constraints (e.g., "DIP-8", "SOIC", "QFN").
 
 **SKiDL Search Query Construction Rules:**
 - Output a *ranked list* of SKiDL search queries for each part, ordered from most general to most specific.
@@ -141,6 +149,12 @@ Your task is to **clean, optimize, and creatively construct multiple SKiDL searc
     - "^irf540n$"
     - "mosfet to-220"
     - "mosfet (to-220|d2pak)"
+
+**Footprint Search Examples:**
+- "DIP-8" → `search_footprints('DIP-8')`
+- "QFN-48" → `search_footprints('QFN-48')`
+- "SOIC surface mount" → `search_footprints('SOIC')`
+- For ICs: search both symbol ("lm324") and package ("DIP-14")
 
 **After constructing the queries you have access to a tool to execute the queries to find the required parts - please make use of it.** 
 """

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -14,3 +14,13 @@ def test_agent_models_from_env(monkeypatch):
     assert mod.plan_editor.model == "y-model"
     assert mod.part_finder.model == "z-model"
 
+
+def test_partfinder_includes_footprint_tool():
+    import sys
+    sys.modules.pop("circuitron.agents", None)
+    import circuitron.config as cfg
+    cfg.setup_environment()
+    mod = importlib.import_module("circuitron.agents")
+    tool_names = [tool.name for tool in mod.part_finder.tools]
+    assert "search_kicad_footprints" in tool_names
+

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -32,3 +32,30 @@ def test_search_kicad_libraries_timeout():
         args = json.dumps({"query": "123"})
         result = asyncio.run(search_kicad_libraries.on_invoke_tool(ctx, args))
         assert "error" in result.lower()
+
+
+def test_search_kicad_footprints():
+    cfg.setup_environment()
+    from circuitron.tools import search_kicad_footprints
+    fake_output = '[{"name": "SOIC-8", "library": "Package_SO", "description": "soic"}]'
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=fake_output, stderr="")
+    with patch("circuitron.tools.subprocess.run", return_value=completed) as run_mock:
+        ctx = RunContextWrapper(context=None)
+        args = json.dumps({"query": "SOIC-8"})
+        result = asyncio.run(search_kicad_footprints.on_invoke_tool(ctx, args))
+        data = json.loads(result)
+        assert data[0]["name"] == "SOIC-8"
+        run_mock.assert_called_once()
+
+
+def test_search_kicad_footprints_timeout():
+    cfg.setup_environment()
+    from circuitron.tools import search_kicad_footprints
+    with patch(
+        "circuitron.tools.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
+    ):
+        ctx = RunContextWrapper(context=None)
+        args = json.dumps({"query": "DIP"})
+        result = asyncio.run(search_kicad_footprints.on_invoke_tool(ctx, args))
+        assert "error" in result.lower()


### PR DESCRIPTION
## Summary
- extend PartFinder prompt with footprint search guidance
- add `search_kicad_footprints` tool for querying KiCad footprint libraries
- register the new tool with the PartFinder agent
- introduce `FoundFootprint` data model
- add unit tests for footprint search tool and agent configuration
- refine PartFinder prompt wording

## Testing
- `ruff check circuitron/agents.py circuitron/models.py circuitron/prompts.py circuitron/tools.py tests/test_agents.py tests/test_tools.py`
- `mypy circuitron tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860434bc620833398d695390f46bdcf