### PR TITLE
Implement Documentation Gathering Agent

### DIFF
--- a/circuitron/models.py
+++ b/circuitron/models.py
@@ -4,6 +4,7 @@ Defines all BaseModels required for getting structured outputs from agents.
 """
 
 from typing import List
+from enum import Enum
 from pydantic import BaseModel, Field, ConfigDict, model_validator
 
 
@@ -182,4 +183,30 @@ class PartSelectionOutput(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
     selections: List[SelectedPart] = Field(default_factory=list, description="Chosen parts with rationale and pin info")
     summary: List[str] = Field(default_factory=list, description="Overall selection rationale")
+
+
+class PriorityLevel(str, Enum):
+    """Priority levels for documentation queries."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class DocumentationOutput(BaseModel):
+    """Complete output from the Documentation Agent."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+    research_queries: List[str] = Field(
+        default_factory=list,
+        description="Prioritized research queries with context",
+    )
+    documentation_findings: List[str] = Field(
+        default_factory=list,
+        description="Research findings with code examples and references",
+    )
+    implementation_readiness: str = Field(
+        ...,
+        description="Assessment of readiness for code generation",
+    )
 

--- a/circuitron/settings.py
+++ b/circuitron/settings.py
@@ -19,7 +19,9 @@ class Settings:
     plan_edit_model: str = os.getenv("PLAN_EDIT_MODEL", "o4-mini")
     part_finder_model: str = os.getenv("PART_FINDER_MODEL", "o4-mini")
     part_selection_model: str = os.getenv("PART_SELECTION_MODEL", "o4-mini")
+    documentation_model: str = os.getenv("DOCUMENTATION_MODEL", "o4-mini")
     calculation_image: str = os.getenv("CALC_IMAGE", "python:3.12-slim")
     kicad_image: str = os.getenv(
         "KICAD_IMAGE", "ghcr.io/circuitron/kicad-skidl:latest"
     )
+    mcp_url: str = os.getenv("MCP_URL", "http://localhost:8051")

--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -4,9 +4,11 @@ Contains calculation tools and other utilities that agents can use.
 """
 
 from agents import function_tool
+from agents.tool import HostedMCPTool
 import subprocess
 import textwrap
 import json
+import os
 from .models import CalcResult
 from .config import settings
 
@@ -195,4 +197,18 @@ print(json.dumps(pins))
     except Exception as exc:  # pragma: no cover - unexpected errors
         return json.dumps({{"error": str(exc)}})
     return proc.stdout.strip()
+
+
+def create_mcp_documentation_tools() -> list[HostedMCPTool]:
+    """Create MCP tools for documentation lookup."""
+    server_url = os.getenv("MCP_URL", settings.mcp_url)
+    tool = HostedMCPTool(
+        tool_config={
+            "type": "mcp",
+            "server_label": "skidl_docs",
+            "server_url": server_url,
+            "require_approval": "never",
+        }
+    )
+    return [tool]
 

--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -6,7 +6,14 @@ Contains formatting, printing, and other helper utilities.
 from typing import List
 from agents.items import ReasoningItem
 from agents.result import RunResult
-from .models import PlanOutput, UserFeedback, PlanEditorOutput, PartFinderOutput, PartSelectionOutput
+from .models import (
+    PlanOutput,
+    UserFeedback,
+    PlanEditorOutput,
+    PartFinderOutput,
+    PartSelectionOutput,
+    DocumentationOutput,
+)
 
 
 def extract_reasoning_summary(run_result: RunResult) -> str:
@@ -258,6 +265,30 @@ def format_part_selection_input(plan: PlanOutput, found: PartFinderOutput) -> st
     return "\n".join(parts)
 
 
+def format_documentation_input(
+    plan: PlanOutput, selection: PartSelectionOutput
+) -> str:
+    """Format input for the Documentation agent."""
+    parts = [
+        "DOCUMENTATION CONTEXT",
+        "=" * 40,
+        "",
+    ]
+    if plan.functional_blocks:
+        parts.extend(["Functional Blocks:", *[f"• {b}" for b in plan.functional_blocks], ""])
+    if plan.implementation_actions:
+        parts.extend(["Implementation Actions:", *[f"{i+1}. {a}" for i, a in enumerate(plan.implementation_actions)], ""])
+    if selection.selections:
+        parts.append("Selected Components:")
+        for part in selection.selections:
+            parts.append(f"- {part.name} ({part.library})")
+            for pin in part.pin_details:
+                parts.append(f"  pin {pin.number}: {pin.name} / {pin.function}")
+        parts.append("")
+    parts.append("Gather SKiDL documentation for these components and connections.")
+    return "\n".join(parts)
+
+
 def pretty_print_edited_plan(edited_output: PlanEditorOutput):
     """Pretty print an edited plan output with change summary."""
     print("\n" + "="*60)
@@ -332,4 +363,15 @@ def pretty_print_selected_parts(selection: PartSelectionOutput) -> None:
             print("Pins:")
             for pin in part.pin_details:
                 print(f"  {pin.number}: {pin.name} / {pin.function}")
+
+
+def pretty_print_documentation(docs: DocumentationOutput) -> None:
+    """Display documentation queries and findings."""
+    print("\n=== DOCUMENTATION QUERIES ===")
+    for q in docs.research_queries:
+        print(f" • {q}")
+    print("\n=== DOCUMENTATION FINDINGS ===")
+    for item in docs.documentation_findings:
+        print(f" • {item}")
+    print(f"\nImplementation Readiness: {docs.implementation_readiness}")
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -10,11 +10,13 @@ def test_agent_models_from_env(monkeypatch):
     cfg.settings.plan_edit_model = "y-model"
     cfg.settings.part_finder_model = "z-model"
     cfg.settings.part_selection_model = "s-model"
+    cfg.settings.documentation_model = "d-model"
     mod = importlib.import_module("circuitron.agents")
     assert mod.planner.model == "x-model"
     assert mod.plan_editor.model == "y-model"
     assert mod.part_finder.model == "z-model"
     assert mod.part_selector.model == "s-model"
+    assert mod.documentation.model == "d-model"
 
 
 def test_partfinder_includes_footprint_tool():
@@ -35,4 +37,13 @@ def test_partselector_includes_pin_tool():
     mod = importlib.import_module("circuitron.agents")
     tool_names = [tool.name for tool in mod.part_selector.tools]
     assert "extract_pin_details" in tool_names
+
+
+def test_documentation_agent_has_mcp_tool():
+    import sys
+    sys.modules.pop("circuitron.agents", None)
+    import circuitron.config as cfg
+    cfg.setup_environment()
+    mod = importlib.import_module("circuitron.agents")
+    assert any(tool.__class__.__name__ == "HostedMCPTool" for tool in mod.documentation.tools)
 

--- a/tests/test_format_input.py
+++ b/tests/test_format_input.py
@@ -1,5 +1,5 @@
-from circuitron.models import PlanOutput, UserFeedback
-from circuitron.utils import format_plan_edit_input
+from circuitron.models import PlanOutput, UserFeedback, SelectedPart, PinDetail, PartSelectionOutput
+from circuitron.utils import format_plan_edit_input, format_documentation_input
 
 
 def test_format_plan_edit_input_includes_sections():
@@ -20,3 +20,14 @@ def test_format_plan_edit_input_includes_sections():
     assert "Functional Blocks:" in text
     assert "Requested Edits:" in text
     assert "Answers to Open Questions:" in text
+
+
+def test_format_documentation_input_includes_parts():
+    plan = PlanOutput(functional_blocks=["Block"], implementation_actions=["Do"])
+    pin = PinDetail(number="1", name="VCC", function="POWER-IN")
+    part = SelectedPart(name="U1", library="lib", pin_details=[pin])
+    selection = PartSelectionOutput(selections=[part])
+    text = format_documentation_input(plan, selection)
+    assert "DOCUMENTATION CONTEXT" in text
+    assert "U1 (lib)" in text
+    assert "pin 1: VCC" in text

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,11 @@
 import pytest
 
-from circuitron.models import PlanOutput, PlanEditDecision, PlanEditorOutput
+from circuitron.models import (
+    PlanOutput,
+    PlanEditDecision,
+    PlanEditorOutput,
+    DocumentationOutput,
+)
 
 
 def test_plan_editor_output_edit():
@@ -20,3 +25,12 @@ def test_plan_editor_output_regenerate():
     decision = PlanEditDecision(action="regenerate_plan", reasoning="redo")
     result = PlanEditorOutput(decision=decision, reconstructed_prompt="new")
     assert result.reconstructed_prompt == "new"
+
+
+def test_documentation_output():
+    out = DocumentationOutput(
+        research_queries=["q"],
+        documentation_findings=["f"],
+        implementation_readiness="ready",
+    )
+    assert out.implementation_readiness == "ready"

--- a/tests/test_part_selection.py
+++ b/tests/test_part_selection.py
@@ -10,6 +10,7 @@ from circuitron.models import (
     PlanOutput,
     PartFinderOutput,
     PartSelectionOutput,
+    DocumentationOutput,
     PlanEditDecision,
     PlanEditorOutput,
     UserFeedback,
@@ -22,12 +23,16 @@ async def fake_pipeline_no_feedback():
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
     part_out = PartFinderOutput(found_components_json="[]")
     select_out = PartSelectionOutput()
+    doc_out = DocumentationOutput(
+        research_queries=[], documentation_findings=[], implementation_readiness="ok"
+    )
     with patch.object(pl, "run_planner", AsyncMock(return_value=plan_result)), \
          patch.object(pl, "run_part_finder", AsyncMock(return_value=part_out)), \
          patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
+         patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
          patch.object(pl, "collect_user_feedback", return_value=UserFeedback()):
         result = await pl.pipeline("test")
-    assert result is select_out
+    assert result is doc_out
 
 
 async def fake_pipeline_edit_plan():
@@ -40,13 +45,17 @@ async def fake_pipeline_edit_plan():
     )
     part_out = PartFinderOutput(found_components_json="[]")
     select_out = PartSelectionOutput()
+    doc_out = DocumentationOutput(
+        research_queries=[], documentation_findings=[], implementation_readiness="ok"
+    )
     with patch.object(pl, "run_planner", AsyncMock(return_value=plan_result)), \
          patch.object(pl, "collect_user_feedback", return_value=UserFeedback(requested_edits=["x"])), \
          patch.object(pl, "run_plan_editor", AsyncMock(return_value=edit_output)), \
          patch.object(pl, "run_part_finder", AsyncMock(return_value=part_out)), \
-         patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)):
+         patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
+         patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)):
         result = await pl.pipeline("test")
-    assert result is select_out
+    assert result is doc_out
 
 
 def test_pipeline_asyncio():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -87,3 +87,13 @@ def test_extract_pin_details_timeout():
         result = asyncio.run(extract_pin_details.on_invoke_tool(ctx, args))
         assert "error" in result.lower()
 
+
+def test_create_mcp_documentation_tools():
+    cfg.setup_environment()
+    from circuitron.tools import create_mcp_documentation_tools
+
+    tools = create_mcp_documentation_tools()
+    assert len(tools) == 1
+    tool = tools[0]
+    assert tool.tool_config["server_url"] == cfg.settings.mcp_url
+


### PR DESCRIPTION
## Summary
- add `documentation_model` and `mcp_url` configuration
- create MCP documentation tool helper
- define DocumentationOutput model and agent
- collect SKiDL docs in pipeline
- format and print documentation context
- update tests for new agent and pipeline stage

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68647820018c8333bb1f90b4ba19e96c