### PR TITLE
Align docs agent and style with OpenAI SDK

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -17,7 +17,7 @@ async def run_circuitron(
 def main():
     """Main entry point for the Circuitron system."""
     setup_environment()
-    from circuitron.pipeline import pipeline, parse_args
+    from circuitron.pipeline import parse_args
 
     args = parse_args()
     prompt = args.prompt or input("Prompt: ")

--- a/tests/test_part_selection.py
+++ b/tests/test_part_selection.py
@@ -1,10 +1,8 @@
 import asyncio
-import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import circuitron.config as cfg
-cfg.setup_environment()
 
 from circuitron.models import (
     PlanOutput,
@@ -15,10 +13,11 @@ from circuitron.models import (
     PlanEditorOutput,
     UserFeedback,
 )
-import circuitron.pipeline as pl
+cfg.setup_environment()
 
 
 async def fake_pipeline_no_feedback():
+    import circuitron.pipeline as pl
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
     part_out = PartFinderOutput(found_components_json="[]")
@@ -36,6 +35,7 @@ async def fake_pipeline_no_feedback():
 
 
 async def fake_pipeline_edit_plan():
+    import circuitron.pipeline as pl
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
     edited_plan = PlanOutput(component_search_queries=["C"])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -13,10 +13,10 @@ from circuitron.models import (
 )
 import circuitron.config as cfg
 cfg.setup_environment()
-from circuitron import pipeline as pl
 
 
 async def fake_pipeline_no_feedback():
+    from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=[])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
     part_out = PartFinderOutput(found_components_json="[]")
@@ -34,6 +34,7 @@ async def fake_pipeline_no_feedback():
 
 
 async def fake_pipeline_edit_plan():
+    from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=[])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
     edited_plan = PlanOutput(component_search_queries=["C"])
@@ -62,6 +63,7 @@ def test_pipeline_asyncio():
 
 
 def test_parse_args():
+    from circuitron import pipeline as pl
     args = pl.parse_args(["prompt", "-r", "-d"])
     assert args.prompt == "prompt"
     assert args.reasoning is True


### PR DESCRIPTION
## Summary
- ensure CLI only imports what's used
- move environment setup in tests to satisfy ruff
- import pipeline lazily in tests
- fix unused imports

## Testing
- `ruff check circuitron tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68647eeb45a8833398114da81f5c94b8