### PR TITLE
Add code generation agent and pipeline stage

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -2,12 +2,12 @@
 
 import asyncio
 from .config import setup_environment
-from .models import PartFinderOutput
+from .models import CodeGenerationOutput
 
 
 async def run_circuitron(
     prompt: str, show_reasoning: bool = False, debug: bool = False
-) -> PartFinderOutput:
+) -> CodeGenerationOutput:
     """Execute the Circuitron workflow using the full pipeline."""
     from circuitron.pipeline import pipeline
 
@@ -25,10 +25,10 @@ def main():
     debug = args.debug
     
     # Execute pipeline
-    part_output = asyncio.run(run_circuitron(prompt, show_reasoning, debug))
-    if part_output:
-        print("\nFOUND COMPONENTS JSON:\n")
-        print(part_output.found_components_json)
+    code_output = asyncio.run(run_circuitron(prompt, show_reasoning, debug))
+    if code_output:
+        print("\n=== GENERATED SKiDL CODE ===\n")
+        print(code_output.complete_skidl_code)
 
 
 if __name__ == "__main__":

--- a/circuitron/models.py
+++ b/circuitron/models.py
@@ -210,3 +210,45 @@ class DocumentationOutput(BaseModel):
         description="Assessment of readiness for code generation",
     )
 
+
+class CodeGenerationOutput(BaseModel):
+    """Complete output from the Code Generation Agent."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    # Complete SKiDL code
+    complete_skidl_code: str = Field(
+        ..., description="Complete executable SKiDL code"
+    )
+
+    # Code metadata as formatted strings
+    imports: List[str] = Field(
+        default_factory=list, description="Required import statements"
+    )
+    power_rails: List[str] = Field(
+        default_factory=list,
+        description="Power rail configurations with names and settings",
+    )
+    components: List[str] = Field(
+        default_factory=list,
+        description="Component instantiations with part and footprint details",
+    )
+    connections: List[str] = Field(
+        default_factory=list,
+        description="Connections between components with net names",
+    )
+    validation_calls: List[str] = Field(
+        default_factory=list, description="ERC and other validation calls"
+    )
+    output_generation: List[str] = Field(
+        default_factory=list, description="Output generation calls"
+    )
+
+    # Implementation notes and assumptions
+    implementation_notes: List[str] = Field(
+        default_factory=list, description="Important implementation notes"
+    )
+    assumptions: List[str] = Field(
+        default_factory=list, description="Assumptions made during generation"
+    )
+

--- a/circuitron/settings.py
+++ b/circuitron/settings.py
@@ -20,6 +20,7 @@ class Settings:
     part_finder_model: str = os.getenv("PART_FINDER_MODEL", "o4-mini")
     part_selection_model: str = os.getenv("PART_SELECTION_MODEL", "o4-mini")
     documentation_model: str = os.getenv("DOCUMENTATION_MODEL", "o4-mini")
+    code_generation_model: str = os.getenv("CODE_GENERATION_MODEL", "o4-mini")
     calculation_image: str = os.getenv("CALC_IMAGE", "python:3.12-slim")
     kicad_image: str = os.getenv(
         "KICAD_IMAGE", "ghcr.io/circuitron/kicad-skidl:latest"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -11,12 +11,14 @@ def test_agent_models_from_env(monkeypatch):
     cfg.settings.part_finder_model = "z-model"
     cfg.settings.part_selection_model = "s-model"
     cfg.settings.documentation_model = "d-model"
+    cfg.settings.code_generation_model = "c-model"
     mod = importlib.import_module("circuitron.agents")
     assert mod.planner.model == "x-model"
     assert mod.plan_editor.model == "y-model"
     assert mod.part_finder.model == "z-model"
     assert mod.part_selector.model == "s-model"
     assert mod.documentation.model == "d-model"
+    assert mod.code_generator.model == "c-model"
 
 
 def test_partfinder_includes_footprint_tool():
@@ -46,4 +48,13 @@ def test_documentation_agent_has_mcp_tool():
     cfg.setup_environment()
     mod = importlib.import_module("circuitron.agents")
     assert any(tool.__class__.__name__ == "HostedMCPTool" for tool in mod.documentation.tools)
+
+
+def test_code_generation_agent_has_mcp_tool():
+    import sys
+    sys.modules.pop("circuitron.agents", None)
+    import circuitron.config as cfg
+    cfg.setup_environment()
+    mod = importlib.import_module("circuitron.agents")
+    assert any(tool.__class__.__name__ == "HostedMCPTool" for tool in mod.code_generator.tools)
 

--- a/tests/test_code_generation.py
+++ b/tests/test_code_generation.py
@@ -1,0 +1,11 @@
+import circuitron.config as cfg
+cfg.setup_environment()
+from circuitron.utils import validate_code_generation_results
+from circuitron.models import CodeGenerationOutput
+
+
+def test_validate_code_generation_results():
+    out = CodeGenerationOutput(complete_skidl_code="from skidl import *\n")
+    assert validate_code_generation_results(out) is True
+    bad = CodeGenerationOutput(complete_skidl_code="print('hi')")
+    assert validate_code_generation_results(bad) is False

--- a/tests/test_format_input.py
+++ b/tests/test_format_input.py
@@ -1,5 +1,16 @@
-from circuitron.models import PlanOutput, UserFeedback, SelectedPart, PinDetail, PartSelectionOutput
-from circuitron.utils import format_plan_edit_input, format_documentation_input
+from circuitron.models import (
+    PlanOutput,
+    UserFeedback,
+    SelectedPart,
+    PinDetail,
+    PartSelectionOutput,
+    DocumentationOutput,
+)
+from circuitron.utils import (
+    format_plan_edit_input,
+    format_documentation_input,
+    format_code_generation_input,
+)
 
 
 def test_format_plan_edit_input_includes_sections():
@@ -31,3 +42,16 @@ def test_format_documentation_input_includes_parts():
     assert "DOCUMENTATION CONTEXT" in text
     assert "U1 (lib)" in text
     assert "pin 1: VCC" in text
+
+
+def test_format_code_generation_input_includes_docs():
+    plan = PlanOutput(functional_blocks=["Block"], implementation_actions=["Do"])
+    pin = PinDetail(number="1", name="VCC", function="POWER-IN")
+    part = SelectedPart(name="U1", library="lib", pin_details=[pin])
+    selection = PartSelectionOutput(selections=[part])
+    docs = DocumentationOutput(
+        research_queries=[], documentation_findings=["example"], implementation_readiness="ok"
+    )
+    text = format_code_generation_input(plan, selection, docs)
+    assert "CODE GENERATION CONTEXT" in text
+    assert "example" in text

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,7 @@ from circuitron.models import (
     PlanEditDecision,
     PlanEditorOutput,
     DocumentationOutput,
+    CodeGenerationOutput,
 )
 
 
@@ -34,3 +35,11 @@ def test_documentation_output():
         implementation_readiness="ready",
     )
     assert out.implementation_readiness == "ready"
+
+
+def test_code_generation_output():
+    out = CodeGenerationOutput(
+        complete_skidl_code="from skidl import *\n",
+        imports=["from skidl import *"],
+    )
+    assert "skidl" in out.complete_skidl_code

--- a/tests/test_part_selection.py
+++ b/tests/test_part_selection.py
@@ -9,6 +9,7 @@ from circuitron.models import (
     PartFinderOutput,
     PartSelectionOutput,
     DocumentationOutput,
+    CodeGenerationOutput,
     PlanEditDecision,
     PlanEditorOutput,
     UserFeedback,
@@ -25,13 +26,15 @@ async def fake_pipeline_no_feedback():
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
     )
+    code_out = CodeGenerationOutput(complete_skidl_code="")
     with patch.object(pl, "run_planner", AsyncMock(return_value=plan_result)), \
          patch.object(pl, "run_part_finder", AsyncMock(return_value=part_out)), \
          patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
          patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
+         patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
          patch.object(pl, "collect_user_feedback", return_value=UserFeedback()):
         result = await pl.pipeline("test")
-    assert result is doc_out
+    assert result is code_out
 
 
 async def fake_pipeline_edit_plan():
@@ -48,14 +51,16 @@ async def fake_pipeline_edit_plan():
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
     )
+    code_out = CodeGenerationOutput(complete_skidl_code="")
     with patch.object(pl, "run_planner", AsyncMock(return_value=plan_result)), \
          patch.object(pl, "collect_user_feedback", return_value=UserFeedback(requested_edits=["x"])), \
          patch.object(pl, "run_plan_editor", AsyncMock(return_value=edit_output)), \
          patch.object(pl, "run_part_finder", AsyncMock(return_value=part_out)), \
          patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
-         patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)):
+         patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
+         patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)):
         result = await pl.pipeline("test")
-    assert result is doc_out
+    assert result is code_out
 
 
 def test_pipeline_asyncio():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -10,6 +10,7 @@ from circuitron.models import (
     PartFinderOutput,
     PartSelectionOutput,
     DocumentationOutput,
+    CodeGenerationOutput,
 )
 import circuitron.config as cfg
 cfg.setup_environment()
@@ -24,13 +25,15 @@ async def fake_pipeline_no_feedback():
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
     )
+    code_out = CodeGenerationOutput(complete_skidl_code="")
     with patch.object(pl, "run_planner", AsyncMock(return_value=plan_result)), \
          patch.object(pl, "run_part_finder", AsyncMock(return_value=part_out)), \
          patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
          patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
+         patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
          patch.object(pl, "collect_user_feedback", return_value=UserFeedback()):
         result = await pl.pipeline("test")
-    assert result is doc_out
+    assert result is code_out
 
 
 async def fake_pipeline_edit_plan():
@@ -47,14 +50,16 @@ async def fake_pipeline_edit_plan():
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
     )
+    code_out = CodeGenerationOutput(complete_skidl_code="")
     with patch.object(pl, "run_planner", AsyncMock(return_value=plan_result)), \
          patch.object(pl, "collect_user_feedback", return_value=UserFeedback(requested_edits=["x"])), \
          patch.object(pl, "run_plan_editor", AsyncMock(return_value=edit_output)), \
          patch.object(pl, "run_part_finder", AsyncMock(return_value=part_out)), \
          patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
-         patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)):
+         patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
+         patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)):
         result = await pl.pipeline("test")
-    assert result is doc_out
+    assert result is code_out
 
 
 def test_pipeline_asyncio():


### PR DESCRIPTION
## Summary
- implement `CodeGenerationOutput` model to describe generated SKiDL code
- create code generation agent with optional MCP tools
- update settings with `code_generation_model`
- add run_code_generation stage and integrate into pipeline and CLI
- provide formatting and validation utilities for generated code
- extend tests for new agent, model, utilities and pipeline flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648b2ec0888333a30f5d0641088440