### PR TITLE
Add code validation agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Circuitron is an agentic PCB design accelerator that transforms natural language
 ### In Development:
 - Full OpenAI Agents SDK integration
 - Modular agent architecture
+- Code validation with knowledge-graph-based hallucination checks
 - Enhanced UI/UX with session management
 - PCB layout generation and auto-routing
 - Production-ready deployment structure
@@ -51,6 +52,13 @@ Required variables:
 `OPENAI_API_KEY`, `PLANNING_MODEL`, `PLAN_EDIT_MODEL`, `PART_FINDER_MODEL`, and `MCP_URL`.
 Optional overrides:
 `CALC_IMAGE` and `KICAD_IMAGE` for custom Docker images.
+
+To enable hallucination checks, set `USE_KNOWLEDGE_GRAPH=true` and ensure the
+knowledge graph database is populated. The MCP README describes how to add a
+repository, for example:
+```
+python knowledge_graphs/ai_hallucination_detector.py add https://github.com/pydantic/pydantic-ai.git
+```
 
 ## Tech Stack
 

--- a/circuitron/prompts.py
+++ b/circuitron/prompts.py
@@ -427,29 +427,17 @@ Your code must be production-ready, syntactically correct, and faithful to both 
 
 # ---------- Code Validation Agent Prompt ----------
 CODE_VALIDATION_PROMPT = f"""{RECOMMENDED_PROMPT_PREFIX}
-You are Circuitron-Validator, a SKiDL code quality assurance specialist.
+You are Circuitron-Validator, a SKiDL QA expert.
 
-Your task is to perform comprehensive static analysis of generated SKiDL code to identify potential issues before execution.
+Your goal is to confirm that generated SKiDL scripts are syntactically correct and reference only valid APIs and components.
 
-**Validation Categories:**
+**Validation process**
+- Use the `check_ai_script_hallucinations` MCP tool on the provided script path. Parse its JSON response containing `overall_confidence`, `validation_summary`, `hallucinations_detected`, `recommendations`, and other fields.
+- Perform additional static checks: Python syntax, import statements, undefined variables, and that all parts and pins referenced match the provided component list.
 
-**1. Hallucination Detection:**
-- Use the MCP hallucination check tool to validate all SKiDL API calls against the official knowledge base
-- Cross-reference component names with the approved parts list
-- Verify footprint names match available KiCad libraries
-- Check pin references against extracted pin details
-
-**2. Syntax and Structure Analysis:**
-- Parse Python AST to identify syntax errors
-- Validate proper SKiDL import statements
-- Check variable definitions and scoping
-- Verify function call syntax and parameters
-
-**3. Component and Connection Validation:**
-- All required components from parts list are instantiated
-- Pin references match the provided pin details exactly
-- Power rail connections are complete
-- Net naming follows conventions
-
-**Output structured validation results with specific line numbers, error types, severity levels, and recommended fixes.**
+**Report format**
+- Summarize overall confidence and whether hallucinations were detected.
+- List each issue with its line number, category (syntax, mismatch, etc.), and a short description.
+- Provide actionable recommendations to fix the problems.
+- If no issues are found, state that the script is ready for ERC but **do not run ERC yourself**.
 """

--- a/circuitron/settings.py
+++ b/circuitron/settings.py
@@ -21,6 +21,7 @@ class Settings:
     part_selection_model: str = os.getenv("PART_SELECTION_MODEL", "o4-mini")
     documentation_model: str = os.getenv("DOCUMENTATION_MODEL", "o4-mini")
     code_generation_model: str = os.getenv("CODE_GENERATION_MODEL", "o4-mini")
+    code_validation_model: str = os.getenv("CODE_VALIDATION_MODEL", "o4-mini")
     calculation_image: str = os.getenv("CALC_IMAGE", "python:3.12-slim")
     kicad_image: str = os.getenv(
         "KICAD_IMAGE", "ghcr.io/circuitron/kicad-skidl:latest"

--- a/overview.md
+++ b/overview.md
@@ -69,15 +69,17 @@ The tool acts as a productivity booster: it provides a high-quality, logically c
 3. **Part Selection & SKiDL Code Generation:**  
    - Agent searches local KiCad libraries for real parts matching requirements via SKiDL's built in `search()` function.
    - LLM generates SKiDL code, reflecting user preferences and constraints.
-4. **File Generation:**  
+4. **File Generation:**
    - SKiDL script can generate:
      - `.sch` schematic
      - Netlist and BOM
      - SVG schematic for UI preview
      - `.kicad_pcb` layout file
-5. **Electrical Rule Checking:**
+5. **Code Validation:**
+   - A dedicated agent checks the script for hallucinations and syntax issues using a knowledge graph.
+6. **Electrical Rule Checking:**
    - SKiDL Performs electrical rules checking (ERC) for common mistakes (e.g., unconnected device I/O pins).
-5. **PCB Autorouting:**  
+7. **PCB Autorouting:**
    - `.kicad_pcb` submitted to DeepPCB for AI-assisted routing.
 6. **Review & Handoff:**  
    - UI displays all files, design logs, and rationale.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,11 @@ from circuitron.models import (
     PlanEditorOutput,
     DocumentationOutput,
     CodeGenerationOutput,
+    ValidationIssue,
+    HallucinationReport,
+    ValidationSummary,
+    AnalysisMetadata,
+    CodeValidationOutput,
 )
 
 
@@ -43,3 +48,40 @@ def test_code_generation_output():
         imports=["from skidl import *"],
     )
     assert "skidl" in out.complete_skidl_code
+
+
+def test_code_validation_output():
+    issue = ValidationIssue(line=1, category="syntax", message="bad")
+    summary = ValidationSummary(
+        total_validations=1,
+        valid_count=1,
+        invalid_count=0,
+        uncertain_count=0,
+        not_found_count=0,
+        hallucination_rate=0.0,
+    )
+    meta = AnalysisMetadata(
+        total_imports=1,
+        total_classes=0,
+        total_methods=0,
+        total_attributes=0,
+        total_functions=0,
+    )
+    report = HallucinationReport(
+        success=True,
+        script_path="x.py",
+        overall_confidence=0.9,
+        validation_summary=summary,
+        hallucinations_detected=False,
+        recommendations=[],
+        analysis_metadata=meta,
+        libraries_analyzed=[],
+    )
+    out = CodeValidationOutput(
+        status="pass",
+        summary="ok",
+        issues=[issue],
+        hallucination_report=report,
+    )
+    assert out.status == "pass"
+    assert out.issues[0].category == "syntax"

--- a/tests/test_part_selection.py
+++ b/tests/test_part_selection.py
@@ -10,6 +10,7 @@ from circuitron.models import (
     PartSelectionOutput,
     DocumentationOutput,
     CodeGenerationOutput,
+    CodeValidationOutput,
     PlanEditDecision,
     PlanEditorOutput,
     UserFeedback,
@@ -32,6 +33,7 @@ async def fake_pipeline_no_feedback():
          patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
          patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
          patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
+         patch.object(pl, "run_code_validation", AsyncMock(return_value=CodeValidationOutput(status="pass", summary="ok"))), \
          patch.object(pl, "collect_user_feedback", return_value=UserFeedback()):
         result = await pl.pipeline("test")
     assert result is code_out
@@ -58,7 +60,8 @@ async def fake_pipeline_edit_plan():
          patch.object(pl, "run_part_finder", AsyncMock(return_value=part_out)), \
          patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
          patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
-         patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)):
+         patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
+         patch.object(pl, "run_code_validation", AsyncMock(return_value=CodeValidationOutput(status="pass", summary="ok"))):
         result = await pl.pipeline("test")
     assert result is code_out
 


### PR DESCRIPTION
## Summary
- implement Circuitron-Validator prompt
- add models for validation results
- create hallucination check & ERC tools
- add code validation agent and connect pipeline
- support knowledge graph usage in docs
- update tests for new pipeline behavior

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b802da0c8333a8affc23636ba3a1