### PR TITLE
Refactor MCP tool helpers

### DIFF
--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -200,32 +200,34 @@ print(json.dumps(pins))
     return proc.stdout.strip()
 
 
-def create_mcp_documentation_tools() -> list[HostedMCPTool]:
-    """Create MCP tools for documentation lookup."""
+def create_mcp_tool(server_label: str) -> HostedMCPTool:
+    """Return a HostedMCPTool configured for the given server label.
+
+    Args:
+        server_label: The target label of the MCP server.
+
+    Returns:
+        HostedMCPTool configured with the appropriate server URL.
+    """
     server_url = os.getenv("MCP_URL", settings.mcp_url)
-    tool = HostedMCPTool(
+    return HostedMCPTool(
         tool_config={
             "type": "mcp",
-            "server_label": "skidl_docs",
+            "server_label": server_label,
             "server_url": server_url,
             "require_approval": "never",
         }
     )
-    return [tool]
+
+
+def create_mcp_documentation_tools() -> list[HostedMCPTool]:
+    """Create MCP tools for documentation lookup."""
+    return [create_mcp_tool("skidl_docs")]
 
 
 def create_mcp_validation_tools() -> list[HostedMCPTool]:
     """Create MCP tool for hallucination checks."""
-    server_url = os.getenv("MCP_URL", settings.mcp_url)
-    tool = HostedMCPTool(
-        tool_config={
-            "type": "mcp",
-            "server_label": "skidl_validation",
-            "server_url": server_url,
-            "require_approval": "never",
-        }
-    )
-    return [tool]
+    return [create_mcp_tool("skidl_validation")]
 
 
 @function_tool

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -90,22 +90,24 @@ def test_extract_pin_details_timeout():
 
 def test_create_mcp_documentation_tools():
     cfg.setup_environment()
-    from circuitron.tools import create_mcp_documentation_tools
+    from circuitron.tools import create_mcp_documentation_tools, create_mcp_tool
 
-    tools = create_mcp_documentation_tools()
-    assert len(tools) == 1
-    tool = tools[0]
-    assert tool.tool_config["server_url"] == cfg.settings.mcp_url
+    dummy_tool = object()
+    with patch("circuitron.tools.create_mcp_tool", return_value=dummy_tool) as helper:
+        tools = create_mcp_documentation_tools()
+        helper.assert_called_once_with("skidl_docs")
+        assert tools == [dummy_tool]
 
 
 def test_create_mcp_validation_tools():
     cfg.setup_environment()
-    from circuitron.tools import create_mcp_validation_tools
+    from circuitron.tools import create_mcp_validation_tools, create_mcp_tool
 
-    tools = create_mcp_validation_tools()
-    assert len(tools) == 1
-    tool = tools[0]
-    assert tool.tool_config["server_url"] == cfg.settings.mcp_url
+    dummy_tool = object()
+    with patch("circuitron.tools.create_mcp_tool", return_value=dummy_tool) as helper:
+        tools = create_mcp_validation_tools()
+        helper.assert_called_once_with("skidl_validation")
+        assert tools == [dummy_tool]
 
 
 def test_run_erc_success():


### PR DESCRIPTION
## Summary
- add `create_mcp_tool` helper for HostedMCPTool creation
- refactor `create_mcp_documentation_tools` and `create_mcp_validation_tools`
- update unit tests for new helper usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c31a0f50833380e095afbe417612