### PR TITLE
Implement code correction agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Circuitron is an agentic PCB design accelerator that transforms natural language
 - Full OpenAI Agents SDK integration
 - Modular agent architecture
 - Code validation with knowledge-graph-based hallucination checks
+- Automated code correction loop to resolve validation and ERC issues
 - Enhanced UI/UX with session management
 - PCB layout generation and auto-routing
 - Production-ready deployment structure

--- a/circuitron/models.py
+++ b/circuitron/models.py
@@ -307,3 +307,26 @@ class CodeValidationOutput(BaseModel):
     summary: str = Field(..., description="Overall validation summary")
     issues: List[ValidationIssue] = Field(default_factory=list)
     hallucination_report: HallucinationReport | None = None
+
+
+class CodeCorrectionOutput(BaseModel):
+    """Complete output from the Code Correction Agent."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    issues_identified: List[str] = Field(
+        default_factory=list,
+        description="All issues identified with type, description, and location",
+    )
+    corrections_made: List[str] = Field(
+        default_factory=list,
+        description="Corrections applied with rationale",
+    )
+    documentation_references: List[str] = Field(
+        default_factory=list,
+        description="Documentation references used",
+    )
+    corrected_code: str = Field(..., description="Complete corrected SKiDL code")
+    validation_notes: str = Field(
+        ..., description="Notes about the validation and correction process"
+    )

--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -481,3 +481,33 @@ def pretty_print_validation(result: CodeValidationOutput) -> None:
             line = f"line {issue.line}: " if issue.line else ""
             print(f" - {line}{issue.category}: {issue.message}")
 
+
+def format_code_correction_input(
+    script_path: str,
+    validation: CodeValidationOutput,
+    erc_result: dict | None = None,
+) -> str:
+    """Format input for the Code Correction agent."""
+
+    parts = [
+        "CODE CORRECTION CONTEXT",
+        "=" * 40,
+        f"Script Path: {script_path}",
+        "",
+        f"Validation Summary: {validation.summary}",
+    ]
+    if validation.issues:
+        parts.append("Issues:")
+        for issue in validation.issues:
+            line = f"line {issue.line}: " if issue.line else ""
+            parts.append(f"- {line}{issue.category}: {issue.message}")
+        parts.append("")
+    if erc_result is not None:
+        parts.append("ERC Result:")
+        parts.append(str(erc_result))
+        parts.append("")
+    parts.append(
+        "Apply iterative corrections until validation passes and ERC shows zero errors."
+    )
+    return "\n".join(parts)
+

--- a/overview.md
+++ b/overview.md
@@ -77,9 +77,11 @@ The tool acts as a productivity booster: it provides a high-quality, logically c
      - `.kicad_pcb` layout file
 5. **Code Validation:**
    - A dedicated agent checks the script for hallucinations and syntax issues using a knowledge graph.
-6. **Electrical Rule Checking:**
+6. **Code Correction Loop:**
+   - If validation fails or ERC reports errors, an automated agent iteratively fixes the code and re-runs checks.
+7. **Electrical Rule Checking:**
    - SKiDL Performs electrical rules checking (ERC) for common mistakes (e.g., unconnected device I/O pins).
-7. **PCB Autorouting:**
+8. **PCB Autorouting:**
    - `.kicad_pcb` submitted to DeepPCB for AI-assisted routing.
 6. **Review & Handoff:**  
    - UI displays all files, design logs, and rationale.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -58,3 +58,14 @@ def test_code_generation_agent_has_mcp_tool():
     mod = importlib.import_module("circuitron.agents")
     assert any(tool.__class__.__name__ == "HostedMCPTool" for tool in mod.code_generator.tools)
 
+
+def test_code_corrector_configuration():
+    import sys
+    sys.modules.pop("circuitron.agents", None)
+    import circuitron.config as cfg
+    cfg.setup_environment()
+    mod = importlib.import_module("circuitron.agents")
+    assert mod.code_corrector.model == cfg.settings.code_validation_model
+    tool_names = [t.name for t in mod.code_corrector.tools]
+    assert "run_erc" in tool_names
+

--- a/tests/test_part_selection.py
+++ b/tests/test_part_selection.py
@@ -33,7 +33,7 @@ async def fake_pipeline_no_feedback():
          patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
          patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
          patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
-         patch.object(pl, "run_code_validation", AsyncMock(return_value=CodeValidationOutput(status="pass", summary="ok"))), \
+         patch.object(pl, "run_code_validation", AsyncMock(return_value=(CodeValidationOutput(status="pass", summary="ok"), {"erc_passed": True}))), \
          patch.object(pl, "collect_user_feedback", return_value=UserFeedback()):
         result = await pl.pipeline("test")
     assert result is code_out
@@ -61,7 +61,7 @@ async def fake_pipeline_edit_plan():
          patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
          patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
          patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
-         patch.object(pl, "run_code_validation", AsyncMock(return_value=CodeValidationOutput(status="pass", summary="ok"))):
+         patch.object(pl, "run_code_validation", AsyncMock(return_value=(CodeValidationOutput(status="pass", summary="ok"), {"erc_passed": True}))):
         result = await pl.pipeline("test")
     assert result is code_out
 


### PR DESCRIPTION
## Summary
- add `CodeCorrectionOutput` model
- implement `Circuitron-Corrector` agent with required tools
- integrate correction loop into the pipeline
- provide formatting helper for code correction
- update tests for new behavior
- document the correction phase in README and overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864dca113648333846917b5cc4b79dd