### PR TITLE
Fix lint issues and reorder imports

### DIFF
--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -9,7 +9,6 @@ import subprocess
 import textwrap
 import json
 import os
-from typing import Any, Dict
 from .models import CalcResult
 from .config import settings
 

--- a/examples/prototype.py
+++ b/examples/prototype.py
@@ -1,9 +1,18 @@
-"""prototype.py"""
+"""Prototype implementation for Circuitron."""
 
-# ---------- Set up tracing and load environment variables ----------
+import asyncio
+import subprocess
+import sys
+import textwrap
+from typing import List
 
 import logfire
 from dotenv import load_dotenv
+from pydantic import BaseModel, ConfigDict, Field
+
+from agents import Agent, Runner, function_tool
+from agents.items import ReasoningItem
+from agents.model_settings import ModelSettings
 
 load_dotenv()
 logfire.configure()
@@ -44,8 +53,6 @@ Focus on creating a complete, actionable plan that later agents can execute. **W
 # This module defines all the BaseModels required for getting structured outputs
 # from each agent in the pipeline, following OpenAI Agents SDK patterns.
 
-from typing import List
-from pydantic import BaseModel, Field, ConfigDict
 
 class PlanOutput(BaseModel):
     """Complete output from the Planning Agent."""
@@ -96,9 +103,6 @@ class CalcResult(BaseModel):
 
 # ========== Calculation Tool ==========
 
-from agents import function_tool
-import subprocess, textwrap
-
 @function_tool
 async def execute_calculation(
     calculation_id: str,
@@ -142,8 +146,6 @@ async def execute_calculation(
 
 # ---------- Reasoning extraction utility ----------
 
-from agents.items import ReasoningItem
-
 def extract_reasoning_summary(run_result):
     """
     Return the concatenated model‐generated reasoning summary text
@@ -160,9 +162,7 @@ def extract_reasoning_summary(run_result):
 
 # ---------- Planning Agent -------------
 
-import asyncio
-from agents import Agent, Runner
-from agents.model_settings import ModelSettings  # <-- Import ModelSettings
+
 
 model_settings = ModelSettings(
     tool_choice="required",
@@ -231,8 +231,6 @@ def pretty_print_plan(plan: PlanOutput):
 
 
 # ---------- Main execution block ----------
-
-import sys
 
 async def run_circuitron(prompt: str):
     return await Runner.run(planner, prompt)

--- a/tests/test_code_generation.py
+++ b/tests/test_code_generation.py
@@ -1,10 +1,10 @@
 import circuitron.config as cfg
-cfg.setup_environment()
-from circuitron.utils import validate_code_generation_results
 from circuitron.models import CodeGenerationOutput
+from circuitron.utils import validate_code_generation_results
 
 
 def test_validate_code_generation_results():
+    cfg.setup_environment()
     out = CodeGenerationOutput(complete_skidl_code="from skidl import *\n")
     assert validate_code_generation_results(out) is True
     bad = CodeGenerationOutput(complete_skidl_code="print('hi')")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -90,7 +90,7 @@ def test_extract_pin_details_timeout():
 
 def test_create_mcp_documentation_tools():
     cfg.setup_environment()
-    from circuitron.tools import create_mcp_documentation_tools, create_mcp_tool
+    from circuitron.tools import create_mcp_documentation_tools
 
     dummy_tool = object()
     with patch("circuitron.tools.create_mcp_tool", return_value=dummy_tool) as helper:
@@ -101,7 +101,7 @@ def test_create_mcp_documentation_tools():
 
 def test_create_mcp_validation_tools():
     cfg.setup_environment()
-    from circuitron.tools import create_mcp_validation_tools, create_mcp_tool
+    from circuitron.tools import create_mcp_validation_tools
 
     dummy_tool = object()
     with patch("circuitron.tools.create_mcp_tool", return_value=dummy_tool) as helper:


### PR DESCRIPTION
## Summary
- clean up unused imports in `circuitron/tools.py`
- reorder module-level imports in `examples/prototype.py`
- fix imports in `tests/test_code_generation.py`
- remove unused imports in `tests/test_tools.py`

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f0b903308333bb47a4d9d765fa01