### PR TITLE
Cleanup type hints and update tool typing

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -14,7 +14,7 @@ async def run_circuitron(
     return await pipeline(prompt, show_reasoning=show_reasoning, debug=debug)
 
 
-def main():
+def main() -> None:
     """Main entry point for the Circuitron system."""
     setup_environment()
     from circuitron.pipeline import parse_args

--- a/circuitron/models.py
+++ b/circuitron/models.py
@@ -110,16 +110,16 @@ class PlanEditorOutput(BaseModel):
         description="Guidance for the Planner when regenerating a plan.",
     )
 
-    @model_validator(mode="after")  # type: ignore[misc,arg-type]
-    def validate_fields(cls, model: "PlanEditorOutput") -> "PlanEditorOutput":
-        action = model.decision.action
-        if action == "edit_plan" and model.updated_plan is None:
+    @model_validator(mode="after")
+    def validate_fields(self) -> "PlanEditorOutput":
+        action = self.decision.action
+        if action == "edit_plan" and self.updated_plan is None:
             raise ValueError("updated_plan must be provided when action is 'edit_plan'")
-        if action == "regenerate_plan" and model.reconstructed_prompt is None:
+        if action == "regenerate_plan" and self.reconstructed_prompt is None:
             raise ValueError(
                 "reconstructed_prompt must be provided when action is 'regenerate_plan'"
             )
-        return model
+        return self
 
 
 # ========== Part Search Agent Models ==========

--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -4,7 +4,7 @@ Contains calculation tools and other utilities that agents can use.
 """
 
 from agents import function_tool
-from agents.tool import HostedMCPTool
+from agents.tool import HostedMCPTool, Tool
 import subprocess
 import textwrap
 import json
@@ -219,12 +219,12 @@ def create_mcp_tool(server_label: str) -> HostedMCPTool:
     )
 
 
-def create_mcp_documentation_tools() -> list[HostedMCPTool]:
+def create_mcp_documentation_tools() -> list[Tool]:
     """Create MCP tools for documentation lookup."""
     return [create_mcp_tool("skidl_docs")]
 
 
-def create_mcp_validation_tools() -> list[HostedMCPTool]:
+def create_mcp_validation_tools() -> list[Tool]:
     """Create MCP tool for hallucination checks."""
     return [create_mcp_tool("skidl_validation")]
 

--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -37,7 +37,7 @@ def extract_reasoning_summary(run_result: RunResult) -> str:
     return "\n\n".join(texts).strip() or "(no summary returned)"
 
 
-def print_section(title: str, items: List[str], bullet: str = "•", numbered: bool = False):
+def print_section(title: str, items: List[str], bullet: str = "•", numbered: bool = False) -> None:
     """Helper function to print a section with consistent formatting."""
     if not items:
         return
@@ -50,7 +50,7 @@ def print_section(title: str, items: List[str], bullet: str = "•", numbered: b
             print(f" {bullet} {item}")
 
 
-def pretty_print_plan(plan: PlanOutput):
+def pretty_print_plan(plan: PlanOutput) -> None:
     """Pretty print a structured plan output."""
     # Section 0: Design Rationale (if provided)
     print_section("Design Rationale", plan.design_rationale)
@@ -294,7 +294,7 @@ def format_documentation_input(
     return "\n".join(parts)
 
 
-def pretty_print_edited_plan(edited_output: PlanEditorOutput):
+def pretty_print_edited_plan(edited_output: PlanEditorOutput) -> None:
     """Pretty print an edited plan output with change summary."""
     print("\n" + "="*60)
     print("PLAN SUCCESSFULLY UPDATED")
@@ -317,7 +317,7 @@ def pretty_print_edited_plan(edited_output: PlanEditorOutput):
         pretty_print_plan(edited_output.updated_plan)
 
 
-def pretty_print_regeneration_prompt(regen_output: PlanEditorOutput):
+def pretty_print_regeneration_prompt(regen_output: PlanEditorOutput) -> None:
     """Pretty print a regeneration prompt output."""
     print("\n" + "="*60)
     print("PLAN REGENERATION REQUIRED")
@@ -485,7 +485,7 @@ def pretty_print_validation(result: CodeValidationOutput) -> None:
 def format_code_correction_input(
     script_path: str,
     validation: CodeValidationOutput,
-    erc_result: dict | None = None,
+    erc_result: dict[str, object] | None = None,
 ) -> str:
     """Format input for the Code Correction agent."""
 


### PR DESCRIPTION
## Summary
- remove unused ignore in models and update model validator signature
- annotate print helpers in `utils`
- use `list[Tool]` when configuring agents
- fix pipeline typing and keep tests passing
- ensure mypy strict typechecks pass

## Testing
- `mypy --strict circuitron`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f34bae788333b73fb6cb9f957ac8