### PR TITLE
Add extensive tests for CLI and pipeline

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,49 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import circuitron.cli as cli
+from circuitron.models import CodeGenerationOutput
+
+
+def test_run_circuitron_invokes_pipeline():
+    out = CodeGenerationOutput(complete_skidl_code="code")
+    async def fake_pipeline(prompt: str, show_reasoning: bool = False, debug: bool = False):
+        assert prompt == "p"
+        assert show_reasoning is True
+        assert debug is False
+        return out
+
+    with patch("circuitron.pipeline.pipeline", AsyncMock(side_effect=fake_pipeline)):
+        result = asyncio.run(cli.run_circuitron("p", show_reasoning=True))
+    assert result is out
+
+
+def test_cli_main_uses_args_and_prints(capsys):
+    out = CodeGenerationOutput(complete_skidl_code="abc")
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
+    with patch("circuitron.cli.setup_environment"), \
+         patch("circuitron.pipeline.parse_args", return_value=args), \
+         patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)):
+        cli.main()
+    captured = capsys.readouterr().out
+    assert "GENERATED SKiDL CODE" in captured
+    assert "abc" in captured
+
+
+def test_cli_main_prompts_for_input(monkeypatch):
+    out = CodeGenerationOutput(complete_skidl_code="xyz")
+    args = SimpleNamespace(prompt=None, reasoning=True, debug=True)
+    with patch("circuitron.cli.setup_environment"), \
+         patch("circuitron.pipeline.parse_args", return_value=args), \
+         patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)) as run_mock:
+        monkeypatch.setattr("builtins.input", lambda _: "hello")
+        cli.main()
+        run_mock.assert_awaited_with("hello", True, True)
+
+
+def test_module_main_called():
+    import runpy
+    with patch("circuitron.cli.main") as main_mock:
+        runpy.run_module("circuitron", run_name="__main__")
+        main_mock.assert_called_once()

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -1,0 +1,135 @@
+import os
+from types import SimpleNamespace
+
+from agents.items import ReasoningItem
+from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
+
+from circuitron.models import (
+    CodeGenerationOutput,
+    PlanOutput,
+    AnalysisMetadata,
+    CodeValidationOutput,
+    HallucinationReport,
+    PartSelectionOutput,
+    PinDetail,
+    SelectedPart,
+    ValidationIssue,
+    ValidationSummary,
+)
+from circuitron.utils import (
+    extract_reasoning_summary,
+    format_code_validation_input,
+    format_code_correction_input,
+    pretty_print_plan,
+    parse_hallucination_report,
+    pretty_print_edited_plan,
+    pretty_print_regeneration_prompt,
+    pretty_print_found_parts,
+    pretty_print_selected_parts,
+    pretty_print_documentation,
+    pretty_print_generated_code,
+    collect_user_feedback,
+    pretty_print_validation,
+    write_temp_skidl_script,
+)
+
+
+def test_extract_reasoning_summary():
+    summary = Summary(text="explain", type="summary_text")
+    rr = ResponseReasoningItem(id="1", summary=[summary], type="reasoning")
+    item = ReasoningItem(agent=SimpleNamespace(), raw_item=rr)
+    result = extract_reasoning_summary(SimpleNamespace(new_items=[item]))
+    assert "explain" in result
+
+
+def test_write_temp_skidl_script(tmp_path):
+    path = write_temp_skidl_script("print('hi')")
+    assert os.path.exists(path)
+    with open(path) as fh:
+        content = fh.read()
+    assert "print('hi')" in content
+    os.remove(path)
+
+
+def test_parse_hallucination_report_roundtrip():
+    summary = ValidationSummary(
+        total_validations=1,
+        valid_count=1,
+        invalid_count=0,
+        uncertain_count=0,
+        not_found_count=0,
+        hallucination_rate=0.0,
+    )
+    meta = AnalysisMetadata(
+        total_imports=0,
+        total_classes=0,
+        total_methods=0,
+        total_attributes=0,
+        total_functions=0,
+    )
+    report = HallucinationReport(
+        success=True,
+        script_path="x.py",
+        overall_confidence=0.9,
+        validation_summary=summary,
+        hallucinations_detected=False,
+        recommendations=[],
+        analysis_metadata=meta,
+        libraries_analyzed=["lib"],
+    )
+    text = report.model_dump_json()
+    parsed = parse_hallucination_report(text)
+    assert parsed.script_path == "x.py"
+    assert parsed.validation_summary.valid_count == 1
+
+
+def test_format_code_validation_and_correction_input():
+    pin = PinDetail(number="1", name="VCC", function="pwr")
+    part = SelectedPart(name="U1", library="lib", footprint="fp", pin_details=[pin])
+    selection = PartSelectionOutput(selections=[part])
+    docs = SimpleNamespace(documentation_findings=["doc"])
+    val = CodeValidationOutput(status="fail", summary="bad", issues=[ValidationIssue(category="err", message="m", line=1)])
+    text = format_code_validation_input("/tmp/s.py", selection, docs)
+    assert "s.py" in text and "U1" in text and "doc" in text
+    corr = format_code_correction_input("/tmp/s.py", val, {"erc_passed": False})
+    assert "Validation Summary: bad" in corr
+    assert "erc_passed" in corr
+
+def test_pretty_print_helpers(capsys):
+    from circuitron.models import PlanEditDecision, PlanEditorOutput, PlanOutput, DocumentationOutput
+    plan = PlanOutput(
+        design_rationale=["why"],
+        functional_blocks=["block"],
+        design_equations=[],
+        implementation_actions=["do"],
+        component_search_queries=["R"],
+        implementation_notes=["note"],
+        design_limitations=["lim"],
+    )
+    pretty_print_plan(plan)
+    cap = capsys.readouterr().out
+    assert "Design Rationale" in cap
+    # edited plan
+    edit = PlanEditorOutput(decision=PlanEditDecision(action="edit_plan", reasoning="r"), updated_plan=plan)
+    pretty_print_edited_plan(edit)
+    regen = PlanEditorOutput(decision=PlanEditDecision(action="regenerate_plan", reasoning="r"), reconstructed_prompt="new")
+    pretty_print_regeneration_prompt(regen)
+    pretty_print_found_parts("[]")
+    selected = PartSelectionOutput(selections=[SelectedPart(name="U1", library="lib", footprint="fp", pin_details=[])])
+    pretty_print_selected_parts(selected)
+    docs = DocumentationOutput(research_queries=["q"], documentation_findings=["doc"], implementation_readiness="ok")
+    pretty_print_documentation(docs)
+    val = CodeValidationOutput(status="pass", summary="ok")
+    pretty_print_generated_code(CodeGenerationOutput(complete_skidl_code="from skidl import *"))
+    pretty_print_validation(val)
+    out = capsys.readouterr().out
+    assert "SELECTED COMPONENTS" in out
+
+def test_collect_user_feedback(monkeypatch):
+    plan = PlanOutput(design_limitations=["q"], component_search_queries=[])
+    answers = iter(["ans", "edit1", "", "req1", ""])
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+    fb = collect_user_feedback(plan)
+    assert fb.open_question_answers[0].startswith("Q1:")
+    assert fb.requested_edits == ["edit1"]
+    assert fb.additional_requirements == ["req1"]


### PR DESCRIPTION
## Summary
- add unit tests for CLI operations and module entry
- test additional pipeline flows including debug and correction branches
- cover helper utilities like collect_user_feedback
- include wrapper tests for pipeline helper functions

## Testing
- `pytest --cov=circuitron -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f77e61cc8333bd165d88eb67cf46