### PR TITLE
Add FastAPI backend and unified Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,64 +1,39 @@
-# Use Ubuntu 20.04 - this is required for KiCad 5.1 compatibility
 FROM ubuntu:20.04
-
-# Set environment variables to non-interactive to avoid prompts during installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install necessary packages: sudo, keyboard-configuration, software-properties-common, wget, unzip, and Python 3
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    sudo \
-    keyboard-configuration \
-    software-properties-common \
-    wget \
-    unzip \
-    python3 \
-    python3-pip \
-    python3-dev \
-    && rm -rf /var/lib/apt/lists/*
+        software-properties-common \
+        wget && rm -rf /var/lib/apt/lists/*
 
-# --- Install KiCad 5.1 using the official PPA ---
-# Add the KiCad PPA for version 5.1 and install KiCad
+# -- KiCad 5.1 --
 RUN add-apt-repository --yes ppa:kicad/kicad-5.1-releases && \
     apt-get update && \
-    apt-get install -y --no-install-recommends kicad && \
+    apt-get install -y --no-install-recommends \
+        kicad \
+        kicad-symbols \
+        kicad-footprints \
+        kicad-packages3d && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# -- Python 3.12 --
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3.12 \
+        python3.12-distutils \
+        python3-pip && \
     rm -rf /var/lib/apt/lists/*
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# --- Install KiCad v5 Symbols ---
-# Set the URL for the KiCad v5 symbols
-ARG KICAD_SYMBOLS_URL="https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/5.1.10/kicad-symbols-5.1.10.zip"
-# Create the target directory for symbols
-RUN mkdir -p /usr/share/kicad/library
-# Download and extract the symbols
-RUN wget -q -O symbols.zip "${KICAD_SYMBOLS_URL}" && \
-    unzip -q symbols.zip -d /usr/share/kicad/library && \
-    mv /usr/share/kicad/library/kicad-symbols-5.1.10/* /usr/share/kicad/library/ && \
-    rm -rf /usr/share/kicad/library/kicad-symbols-5.1.10 && \
-    rm symbols.zip
+RUN pip3 install --no-cache-dir poetry
+ENV POETRY_VIRTUALENVS_CREATE=false
+WORKDIR /app
 
-# --- Install KiCad v5 Footprints ---
-# Set the URL for the KiCad v5 footprints
-ARG KICAD_FOOTPRINTS_URL="https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/5.1.10/kicad-footprints-5.1.10.zip"
-# Create the target directory for footprints
-RUN mkdir -p /usr/share/kicad/modules
-# Download and extract the footprints
-RUN wget -q -O footprints.zip "${KICAD_FOOTPRINTS_URL}" && \
-    unzip -q footprints.zip -d /usr/share/kicad/modules && \
-    mv /usr/share/kicad/modules/kicad-footprints-5.1.10/* /usr/share/kicad/modules/ && \
-    rm -rf /usr/share/kicad/modules/kicad-footprints-5.1.10 && \
-    rm footprints.zip
+COPY pyproject.toml poetry.lock* ./
+RUN poetry install --no-dev --no-interaction --no-ansi
 
-# --- Configure Environment for SKiDL ---
-# Set environment variables to point SKiDL to the new library locations
-ENV KICAD_SYMBOL_DIR="/usr/share/kicad/library"
-ENV KICAD_FOOTPRINT_DIR="/usr/share/kicad/modules"
+COPY . .
 
-# --- Install SKiDL and Python Development Tools ---
-# Upgrade pip and install the skidl library and other useful Python packages
-RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    python3 -m pip install --no-cache-dir skidl numpy matplotlib
-
-# Set working directory
-WORKDIR /workspace
-
-# Set the default command to run when the container starts
-CMD ["python3"]
+EXPOSE 8000
+CMD ["uvicorn", "backend.api:app", "--host", "0.0.0.0", "--port", "8000"]
+# VOLUME ["./backend:/app/backend"]

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import io
+from contextlib import redirect_stdout
+
+# Repo scan summary:
+# CLI entry: circuitron/cli.py -> calls pipeline.pipeline
+# Core orchestration in circuitron/pipeline.py
+# Agents defined in circuitron/agents.py
+# Tools containerize KiCad/SKiDL via Docker in circuitron/tools.py
+# Many modules print to stdout which will be captured here
+
+app = FastAPI()
+
+class RunRequest(BaseModel):
+    job_params: str
+
+@app.post("/run")
+async def run_job(req: RunRequest):
+    """Execute the Circuitron pipeline and capture stdout."""
+    from circuitron.pipeline import pipeline
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result = await pipeline(req.job_params)
+    return {"status": "ok", "stdout": buf.getvalue(), "result": result.model_dump()}

--- a/circuitron/config.py
+++ b/circuitron/config.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 from .settings import Settings
 
-settings: Settings
+settings: Settings = Settings()
 
 
 def setup_environment() -> None:

--- a/circuitron/settings.py
+++ b/circuitron/settings.py
@@ -23,7 +23,5 @@ class Settings:
     code_generation_model: str = os.getenv("CODE_GENERATION_MODEL", "o4-mini")
     code_validation_model: str = os.getenv("CODE_VALIDATION_MODEL", "o4-mini")
     calculation_image: str = os.getenv("CALC_IMAGE", "python:3.12-slim")
-    kicad_image: str = os.getenv(
-        "KICAD_IMAGE", "ghcr.io/shaurya-sethi/circuitron-kicad:latest"
-    )
+    kicad_image: str = os.getenv("KICAD_IMAGE", "circuitron-backend")
     mcp_url: str = os.getenv("MCP_URL", "http://localhost:8051")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "openai-agents==0.1.0",
     "python-dotenv>=1.1.0",
     "skidl>=2.0.1",
+    "fastapi>=0.111.0",
+    "uvicorn[standard]>=0.27.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add a FastAPI service with `/run` endpoint capturing stdout
- update dependencies for FastAPI server
- add unified Dockerfile based on Ubuntu 20.04 with KiCad 5.1
- initialize `settings` on import and default KiCad image to `circuitron-backend`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686547a93c1c833389a27692ec5261c7