### PR TITLE
Remove unused imports

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -2,7 +2,6 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 import io
 from contextlib import redirect_stdout, redirect_stderr
-from typing import Any
 
 from circuitron.models import UserFeedback
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from pathlib import Path


### PR DESCRIPTION
## Summary
- clean up unused imports in backend/api.py and tests/test_api.py
- verify ruff passes

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68656f91e8988333a6c37d7a793897f5