### PR TITLE
Fix mypy errors and add annotations

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 import io
 from contextlib import redirect_stdout, redirect_stderr
+from typing import Any
 
 from circuitron.models import UserFeedback
 
@@ -21,7 +22,7 @@ class RunRequest(BaseModel):
     user_feedback: UserFeedback | None = None
 
 @app.post("/run")
-async def run_job(req: RunRequest):
+async def run_job(req: RunRequest) -> dict[str, Any]:
     """Execute the Circuitron pipeline and capture stdout and stderr."""
     from circuitron.pipeline import pipeline
 

--- a/examples/prototype.py
+++ b/examples/prototype.py
@@ -11,8 +11,9 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict, Field
 
 from agents import Agent, Runner, function_tool
+from agents.result import RunResult
 from agents.items import ReasoningItem
-from agents.model_settings import ModelSettings, Reasoning
+from agents.model_settings import ModelSettings, Reasoning  # type: ignore[attr-defined]
 
 load_dotenv()
 logfire.configure()
@@ -146,7 +147,7 @@ async def execute_calculation(
 
 # ---------- Reasoning extraction utility ----------
 
-def extract_reasoning_summary(run_result):
+def extract_reasoning_summary(run_result: RunResult) -> str:
     """
     Return the concatenated model‐generated reasoning summary text
     from ResponseReasoningItem.raw_item.summary entries.
@@ -180,7 +181,7 @@ planner = Agent(
 
 # ---------- Pretty printing utilities ----------
 
-def print_section(title: str, items: List[str], bullet: str = "•", numbered: bool = False):
+def print_section(title: str, items: List[str], bullet: str = "•", numbered: bool = False) -> None:
     """Helper function to print a section with consistent formatting."""
     if not items:
         return
@@ -192,7 +193,7 @@ def print_section(title: str, items: List[str], bullet: str = "•", numbered: b
         else:
             print(f" {bullet} {item}")
 
-def pretty_print_plan(plan: PlanOutput):
+def pretty_print_plan(plan: PlanOutput) -> None:
     # Section 0: Design Rationale (if provided)
     print_section("Design Rationale", plan.design_rationale)
 
@@ -229,7 +230,7 @@ def pretty_print_plan(plan: PlanOutput):
 
 # ---------- Main execution block ----------
 
-async def run_circuitron(prompt: str):
+async def run_circuitron(prompt: str) -> RunResult:
     return await Runner.run(planner, prompt)
 
 if __name__ == "__main__":

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,7 +1,10 @@
 import importlib
 
 
-def test_agent_models_from_env(monkeypatch):
+import pytest
+
+
+def test_agent_models_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
@@ -21,7 +24,7 @@ def test_agent_models_from_env(monkeypatch):
     assert mod.code_generator.model == "c-model"
 
 
-def test_partfinder_includes_footprint_tool():
+def test_partfinder_includes_footprint_tool() -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
@@ -31,7 +34,7 @@ def test_partfinder_includes_footprint_tool():
     assert "search_kicad_footprints" in tool_names
 
 
-def test_partselector_includes_pin_tool():
+def test_partselector_includes_pin_tool() -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
@@ -41,7 +44,7 @@ def test_partselector_includes_pin_tool():
     assert "extract_pin_details" in tool_names
 
 
-def test_documentation_agent_has_mcp_tool():
+def test_documentation_agent_has_mcp_tool() -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
@@ -50,7 +53,7 @@ def test_documentation_agent_has_mcp_tool():
     assert any(tool.__class__.__name__ == "HostedMCPTool" for tool in mod.documentation.tools)
 
 
-def test_code_generation_agent_has_mcp_tool():
+def test_code_generation_agent_has_mcp_tool() -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
@@ -59,7 +62,7 @@ def test_code_generation_agent_has_mcp_tool():
     assert any(tool.__class__.__name__ == "HostedMCPTool" for tool in mod.code_generator.tools)
 
 
-def test_code_corrector_configuration():
+def test_code_corrector_configuration() -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,10 +9,17 @@ from backend.api import app
 from circuitron.models import CodeGenerationOutput, UserFeedback
 
 
-def test_run_endpoint_returns_result():
+def test_run_endpoint_returns_result() -> None:
     out = CodeGenerationOutput(complete_skidl_code="code")
 
-    async def fake_pipeline(prompt: str, show_reasoning: bool = False, debug: bool = False, *, user_feedback: UserFeedback | None = None, interactive: bool = True):
+    async def fake_pipeline(
+        prompt: str,
+        show_reasoning: bool = False,
+        debug: bool = False,
+        *,
+        user_feedback: UserFeedback | None = None,
+        interactive: bool = True,
+    ) -> CodeGenerationOutput:
         assert prompt == "p"
         assert show_reasoning is False
         assert debug is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,20 +7,20 @@ from circuitron.models import CodeGenerationOutput
 
 
 class FakeResponse:
-    def __init__(self, data: dict):
+    def __init__(self, data: dict[str, object]):
         self._data = data
 
     def raise_for_status(self) -> None:
         pass
 
-    def json(self) -> dict:
+    def json(self) -> dict[str, object]:
         return self._data
 
 
-def test_run_circuitron_invokes_backend():
+def test_run_circuitron_invokes_backend() -> None:
     out = CodeGenerationOutput(complete_skidl_code="code")
 
-    async def fake_post(url: str, json: dict) -> FakeResponse:
+    async def fake_post(url: str, json: dict[str, object]) -> FakeResponse:
         assert "p" == json["prompt"]
         assert json["reasoning"] is True
         assert json["debug"] is False
@@ -35,7 +35,10 @@ def test_run_circuitron_invokes_backend():
     assert result == out
 
 
-def test_cli_main_uses_args_and_prints(capsys):
+import pytest
+
+
+def test_cli_main_uses_args_and_prints(capsys: pytest.CaptureFixture[str]) -> None:
     out = CodeGenerationOutput(complete_skidl_code="abc")
     args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
     with patch("circuitron.cli.setup_environment"), \
@@ -47,7 +50,7 @@ def test_cli_main_uses_args_and_prints(capsys):
     assert "abc" in captured
 
 
-def test_cli_main_prompts_for_input(monkeypatch):
+def test_cli_main_prompts_for_input(monkeypatch: pytest.MonkeyPatch) -> None:
     out = CodeGenerationOutput(complete_skidl_code="xyz")
     args = SimpleNamespace(prompt=None, reasoning=True, debug=True)
     with patch("circuitron.cli.setup_environment"), \
@@ -58,7 +61,7 @@ def test_cli_main_prompts_for_input(monkeypatch):
         run_mock.assert_awaited_with("hello", True, True)
 
 
-def test_module_main_called():
+def test_module_main_called() -> None:
     import runpy
     with patch("circuitron.cli.main") as main_mock:
         runpy.run_module("circuitron", run_name="__main__")

--- a/tests/test_code_generation.py
+++ b/tests/test_code_generation.py
@@ -3,7 +3,7 @@ from circuitron.models import CodeGenerationOutput
 from circuitron.utils import validate_code_generation_results
 
 
-def test_validate_code_generation_results():
+def test_validate_code_generation_results() -> None:
     cfg.setup_environment()
     out = CodeGenerationOutput(complete_skidl_code="from skidl import *\n")
     assert validate_code_generation_results(out) is True

--- a/tests/test_format_input.py
+++ b/tests/test_format_input.py
@@ -13,7 +13,7 @@ from circuitron.utils import (
 )
 
 
-def test_format_plan_edit_input_includes_sections():
+def test_format_plan_edit_input_includes_sections() -> None:
     plan = PlanOutput(
         design_rationale=["Reason"],
         functional_blocks=["Block"],
@@ -33,7 +33,7 @@ def test_format_plan_edit_input_includes_sections():
     assert "Answers to Open Questions:" in text
 
 
-def test_format_documentation_input_includes_parts():
+def test_format_documentation_input_includes_parts() -> None:
     plan = PlanOutput(functional_blocks=["Block"], implementation_actions=["Do"])
     pin = PinDetail(number="1", name="VCC", function="POWER-IN")
     part = SelectedPart(name="U1", library="lib", pin_details=[pin])
@@ -44,7 +44,7 @@ def test_format_documentation_input_includes_parts():
     assert "pin 1: VCC" in text
 
 
-def test_format_code_generation_input_includes_docs():
+def test_format_code_generation_input_includes_docs() -> None:
     plan = PlanOutput(functional_blocks=["Block"], implementation_actions=["Do"])
     pin = PinDetail(number="1", name="VCC", function="POWER-IN")
     part = SelectedPart(name="U1", library="lib", pin_details=[pin])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,26 +14,26 @@ from circuitron.models import (
 )
 
 
-def test_plan_editor_output_edit():
+def test_plan_editor_output_edit() -> None:
     plan = PlanOutput()
     decision = PlanEditDecision(action="edit_plan", reasoning="ok")
     result = PlanEditorOutput(decision=decision, updated_plan=plan)
     assert result.updated_plan is plan
 
 
-def test_plan_editor_output_edit_missing_plan():
+def test_plan_editor_output_edit_missing_plan() -> None:
     decision = PlanEditDecision(action="edit_plan", reasoning="bad")
     with pytest.raises(ValueError):
         PlanEditorOutput(decision=decision)
 
 
-def test_plan_editor_output_regenerate():
+def test_plan_editor_output_regenerate() -> None:
     decision = PlanEditDecision(action="regenerate_plan", reasoning="redo")
     result = PlanEditorOutput(decision=decision, reconstructed_prompt="new")
     assert result.reconstructed_prompt == "new"
 
 
-def test_documentation_output():
+def test_documentation_output() -> None:
     out = DocumentationOutput(
         research_queries=["q"],
         documentation_findings=["f"],
@@ -42,7 +42,7 @@ def test_documentation_output():
     assert out.implementation_readiness == "ready"
 
 
-def test_code_generation_output():
+def test_code_generation_output() -> None:
     out = CodeGenerationOutput(
         complete_skidl_code="from skidl import *\n",
         imports=["from skidl import *"],
@@ -50,7 +50,7 @@ def test_code_generation_output():
     assert "skidl" in out.complete_skidl_code
 
 
-def test_code_validation_output():
+def test_code_validation_output() -> None:
     issue = ValidationIssue(line=1, category="syntax", message="bad")
     summary = ValidationSummary(
         total_validations=1,

--- a/tests/test_part_selection.py
+++ b/tests/test_part_selection.py
@@ -18,7 +18,7 @@ from circuitron.models import (
 cfg.setup_environment()
 
 
-async def fake_pipeline_no_feedback():
+async def fake_pipeline_no_feedback() -> None:
     import circuitron.pipeline as pl
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -39,7 +39,7 @@ async def fake_pipeline_no_feedback():
     assert result is code_out
 
 
-async def fake_pipeline_edit_plan():
+async def fake_pipeline_edit_plan() -> None:
     import circuitron.pipeline as pl
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -66,7 +66,7 @@ async def fake_pipeline_edit_plan():
     assert result is code_out
 
 
-def test_pipeline_asyncio():
+def test_pipeline_asyncio() -> None:
     asyncio.run(fake_pipeline_no_feedback())
     asyncio.run(fake_pipeline_edit_plan())
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -17,7 +17,7 @@ import circuitron.config as cfg
 cfg.setup_environment()
 
 
-async def fake_pipeline_no_feedback():
+async def fake_pipeline_no_feedback() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=[])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -38,7 +38,7 @@ async def fake_pipeline_no_feedback():
     assert result is code_out
 
 
-async def fake_pipeline_edit_plan():
+async def fake_pipeline_edit_plan() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=[])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -65,12 +65,12 @@ async def fake_pipeline_edit_plan():
     assert result is code_out
 
 
-def test_pipeline_asyncio():
+def test_pipeline_asyncio() -> None:
     asyncio.run(fake_pipeline_no_feedback())
     asyncio.run(fake_pipeline_edit_plan())
 
 
-def test_parse_args():
+def test_parse_args() -> None:
     from circuitron import pipeline as pl
     args = pl.parse_args(["prompt", "-r", "-d"])
     assert args.prompt == "prompt"
@@ -78,7 +78,7 @@ def test_parse_args():
     assert args.debug is True
 
 
-def test_run_code_validation_calls_erc():
+def test_run_code_validation_calls_erc() -> None:
     import circuitron.pipeline as pl
     code_out = CodeGenerationOutput(complete_skidl_code="from skidl import *")
     selection = PartSelectionOutput()
@@ -91,10 +91,11 @@ def test_run_code_validation_calls_erc():
             erc_mock.assert_called_once()
     validation, erc = result
     assert validation.status == "pass"
+    assert erc is not None
     assert erc["erc_passed"] is True
 
 
-def test_run_code_validation_no_erc_on_fail():
+def test_run_code_validation_no_erc_on_fail() -> None:
     import circuitron.pipeline as pl
     code_out = CodeGenerationOutput(complete_skidl_code="from skidl import *")
     selection = PartSelectionOutput()
@@ -110,7 +111,7 @@ def test_run_code_validation_no_erc_on_fail():
     assert erc is None
 
 
-async def fake_pipeline_with_correction():
+async def fake_pipeline_with_correction() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput()
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -134,12 +135,12 @@ async def fake_pipeline_with_correction():
     assert result.complete_skidl_code == "fixed"
 
 
-def test_pipeline_correction_flow():
+def test_pipeline_correction_flow() -> None:
     asyncio.run(fake_pipeline_with_correction())
 
 
 
-async def fake_pipeline_debug_show():
+async def fake_pipeline_debug_show() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=["print(1)"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -158,10 +159,10 @@ async def fake_pipeline_debug_show():
     assert result is code_out
 
 
-def test_pipeline_debug_show_flow():
+def test_pipeline_debug_show_flow() -> None:
     asyncio.run(fake_pipeline_debug_show())
 
-async def fake_pipeline_edit_plan_with_correction():
+async def fake_pipeline_edit_plan_with_correction() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -190,10 +191,10 @@ async def fake_pipeline_edit_plan_with_correction():
     assert result.complete_skidl_code == "fixed"
 
 
-def test_pipeline_edit_plan_with_correction():
+def test_pipeline_edit_plan_with_correction() -> None:
     asyncio.run(fake_pipeline_edit_plan_with_correction())
 
-async def fake_pipeline_regen_with_correction():
+async def fake_pipeline_regen_with_correction() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput()
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -223,5 +224,5 @@ async def fake_pipeline_regen_with_correction():
     assert result.complete_skidl_code == "fixed"
 
 
-def test_pipeline_regen_with_correction():
+def test_pipeline_regen_with_correction() -> None:
     asyncio.run(fake_pipeline_regen_with_correction())

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -1,6 +1,8 @@
 import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
+from typing import Any, cast
+import pytest
 
 import circuitron.pipeline as pl
 from circuitron.models import (
@@ -17,12 +19,12 @@ from circuitron.models import (
 )
 
 
-async def run_wrappers():
+async def run_wrappers() -> None:
     with patch("circuitron.pipeline.run_erc", AsyncMock(return_value="{}")), \
          patch("circuitron.pipeline.Runner.run", AsyncMock()) as run_mock:
         run_mock.return_value = SimpleNamespace(final_output=PlanOutput())
         await pl.run_planner("p")
-        run_mock.assert_awaited_with(pl.planner, "p")
+        run_mock.assert_awaited_with(getattr(pl, "planner"), "p")
         run_mock.reset_mock()
 
         run_mock.return_value = SimpleNamespace(final_output=PlanEditorOutput(decision=PlanEditDecision(action="edit_plan", reasoning="x"), updated_plan=PlanOutput()))
@@ -53,13 +55,15 @@ async def run_wrappers():
         await pl.run_code_correction(CodeGenerationOutput(complete_skidl_code="code"), CodeValidationOutput(status="fail", summary="bad"))
 
 
-def test_wrapper_functions():
+def test_wrapper_functions() -> None:
     asyncio.run(run_wrappers())
 
 
-def test_pipeline_main(monkeypatch):
+def test_pipeline_main(monkeypatch: pytest.MonkeyPatch) -> None:
     args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
     monkeypatch.setattr(pl, "parse_args", lambda argv=None: args)
     monkeypatch.setattr(pl, "pipeline", AsyncMock())
     asyncio.run(pl.main())
-    pl.pipeline.assert_awaited_with("p", show_reasoning=False, debug=False)
+    cast(AsyncMock, pl.pipeline).assert_awaited_with(
+        "p", show_reasoning=False, debug=False
+    )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,12 +2,13 @@ import asyncio
 import json
 import subprocess
 from unittest.mock import patch
+from typing import Any, Coroutine, cast
 
 from agents.tool_context import ToolContext
 import circuitron.config as cfg
 
 
-def test_search_kicad_libraries():
+def test_search_kicad_libraries() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_libraries
     fake_output = '[{"name": "LM324", "library": "linear", "footprint": "DIP-14", "description": "op amp"}]'
@@ -15,13 +16,15 @@ def test_search_kicad_libraries():
     with patch("circuitron.tools.subprocess.run", return_value=completed) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t1")
         args = json.dumps({"query": "opamp lm324"})
-        result = asyncio.run(search_kicad_libraries.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(
+            cast(Coroutine[Any, Any, str], search_kicad_libraries.on_invoke_tool(ctx, args))
+        )
         data = json.loads(result)
         assert data[0]["name"] == "LM324"
         run_mock.assert_called_once()
 
 
-def test_search_kicad_libraries_timeout():
+def test_search_kicad_libraries_timeout() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_libraries
     with patch(
@@ -30,11 +33,13 @@ def test_search_kicad_libraries_timeout():
     ):
         ctx = ToolContext(context=None, tool_call_id="t2")
         args = json.dumps({"query": "123"})
-        result = asyncio.run(search_kicad_libraries.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(
+            cast(Coroutine[Any, Any, str], search_kicad_libraries.on_invoke_tool(ctx, args))
+        )
         assert "error" in result.lower()
 
 
-def test_search_kicad_footprints():
+def test_search_kicad_footprints() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_footprints
     fake_output = '[{"name": "SOIC-8", "library": "Package_SO", "description": "soic"}]'
@@ -42,13 +47,15 @@ def test_search_kicad_footprints():
     with patch("circuitron.tools.subprocess.run", return_value=completed) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t3")
         args = json.dumps({"query": "SOIC-8"})
-        result = asyncio.run(search_kicad_footprints.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(
+            cast(Coroutine[Any, Any, str], search_kicad_footprints.on_invoke_tool(ctx, args))
+        )
         data = json.loads(result)
         assert data[0]["name"] == "SOIC-8"
         run_mock.assert_called_once()
 
 
-def test_search_kicad_footprints_timeout():
+def test_search_kicad_footprints_timeout() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_footprints
     with patch(
@@ -57,11 +64,13 @@ def test_search_kicad_footprints_timeout():
     ):
         ctx = ToolContext(context=None, tool_call_id="t4")
         args = json.dumps({"query": "DIP"})
-        result = asyncio.run(search_kicad_footprints.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(
+            cast(Coroutine[Any, Any, str], search_kicad_footprints.on_invoke_tool(ctx, args))
+        )
         assert "error" in result.lower()
 
 
-def test_extract_pin_details():
+def test_extract_pin_details() -> None:
     cfg.setup_environment()
     from circuitron.tools import extract_pin_details
     fake_output = '[{"number": "1", "name": "VCC", "function": "POWER"}]'
@@ -69,13 +78,15 @@ def test_extract_pin_details():
     with patch("circuitron.tools.subprocess.run", return_value=completed) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t5")
         args = json.dumps({"library": "linear", "part_name": "lm386"})
-        result = asyncio.run(extract_pin_details.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(
+            cast(Coroutine[Any, Any, str], extract_pin_details.on_invoke_tool(ctx, args))
+        )
         data = json.loads(result)
         assert data[0]["name"] == "VCC"
         run_mock.assert_called_once()
 
 
-def test_extract_pin_details_timeout():
+def test_extract_pin_details_timeout() -> None:
     cfg.setup_environment()
     from circuitron.tools import extract_pin_details
     with patch(
@@ -84,11 +95,13 @@ def test_extract_pin_details_timeout():
     ):
         ctx = ToolContext(context=None, tool_call_id="t6")
         args = json.dumps({"library": "lin", "part_name": "bad"})
-        result = asyncio.run(extract_pin_details.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(
+            cast(Coroutine[Any, Any, str], extract_pin_details.on_invoke_tool(ctx, args))
+        )
         assert "error" in result.lower()
 
 
-def test_create_mcp_documentation_tools():
+def test_create_mcp_documentation_tools() -> None:
     cfg.setup_environment()
     from circuitron.tools import create_mcp_documentation_tools
 
@@ -99,7 +112,7 @@ def test_create_mcp_documentation_tools():
         assert tools == [dummy_tool]
 
 
-def test_create_mcp_validation_tools():
+def test_create_mcp_validation_tools() -> None:
     cfg.setup_environment()
     from circuitron.tools import create_mcp_validation_tools
 
@@ -110,7 +123,7 @@ def test_create_mcp_validation_tools():
         assert tools == [dummy_tool]
 
 
-def test_run_erc_success():
+def test_run_erc_success() -> None:
     cfg.setup_environment()
     from circuitron.tools import run_erc
 
@@ -118,12 +131,14 @@ def test_run_erc_success():
     with patch("circuitron.tools.subprocess.run", return_value=completed) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t7")
         args = json.dumps({"script_path": "/tmp/a.py"})
-        result = asyncio.run(run_erc.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(
+            cast(Coroutine[Any, Any, str], run_erc.on_invoke_tool(ctx, args))
+        )
         assert "{}" in result
         run_mock.assert_called_once()
 
 
-def test_run_erc_timeout():
+def test_run_erc_timeout() -> None:
     cfg.setup_environment()
     from circuitron.tools import run_erc
 
@@ -133,6 +148,8 @@ def test_run_erc_timeout():
     ):
         ctx = ToolContext(context=None, tool_call_id="t8")
         args = json.dumps({"script_path": "/tmp/a.py"})
-        result = asyncio.run(run_erc.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(
+            cast(Coroutine[Any, Any, str], run_erc.on_invoke_tool(ctx, args))
+        )
         assert "success" in result
 


### PR DESCRIPTION
## Summary
- annotate tests and backend for mypy strict compliance
- stub non-exported `planner` access in tests
- update example script annotations

## Testing
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686572345a348333b3067b21ac8c017a