### PR TITLE
Add colorful CIRCUITRON banner and theme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,26 @@ After installation:
 circuitron "Design a voltage divider"
 ```
 
+### Run the Node.js TUI
+
+First build the TypeScript sources:
+
+```bash
+npm run build
+node packages/cli/dist/index.js
+```
+
+After installing globally you can run:
+
+```bash
+circuitron-cli
+```
+
+The TUI attempts to connect to `http://localhost:8000` on start. Set
+`CIRCUITRON_BACKEND_URL` to point at a different server.
+Set `CIRCUITRON_THEME` to `dark`, `light`, or `sunset` to change the color
+scheme.
+
 ### Run the Backend API (Docker)
 
 Start the FastAPI server using uvicorn inside the provided Docker container:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "ink": "^4.2.0",
         "react": "^18.3.1"
       },
+      "bin": {
+        "circuitron-cli": "packages/cli/dist/index.js"
+      },
       "devDependencies": {
         "@types/ink-testing-library": "^1.0.4",
         "@types/jest": "^29.5.11",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"
+  },
+  "bin": {
+    "circuitron-cli": "packages/cli/dist/index.js"
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,0 @@
-import React from 'react';
-import { render } from 'ink';
-import App from './ui/App';
-
-render(<App />);

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from 'ink';
+import App from './ui/App';
+import { themeManager } from './ui/themes/themeManager';
+
+const themeName = process.env.CIRCUITRON_THEME || 'dark';
+themeManager.setActiveTheme(themeName);
+
+render(<App />);

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -1,22 +1,22 @@
-import React, { useEffect, useState } from 'react';
-import { Text } from 'ink';
-import axios from 'axios';
+import React from 'react';
+import { Box, Text } from 'ink';
+import AsciiArt from './components/AsciiArt';
+import { BackendProvider, useBackendContext } from './contexts/BackendContext';
 
 const BACKEND_URL = process.env.CIRCUITRON_BACKEND_URL || 'http://localhost:8000';
 
-const App: React.FC = () => {
-  const [message, setMessage] = useState('Connecting to backend...');
-
-  useEffect(() => {
-    axios
-      .post(`${BACKEND_URL}/run`, { prompt: 'ping' })
-      .then((res) => {
-        setMessage(res.data.status ?? 'ok');
-      })
-      .catch(() => setMessage('Failed to connect'));
-  }, []);
-
-  return <Text>{message}</Text>;
+const Status: React.FC = () => {
+  const { connected } = useBackendContext();
+  return <Text>{connected ? 'Connected to backend' : 'Failed to connect'}</Text>;
 };
+
+const App: React.FC = () => (
+  <BackendProvider url={BACKEND_URL}>
+    <Box flexDirection="column">
+      <AsciiArt />
+      <Status />
+    </Box>
+  </BackendProvider>
+);
 
 export default App;

--- a/packages/cli/src/ui/components/AsciiArt.tsx
+++ b/packages/cli/src/ui/components/AsciiArt.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Text, Box, useStdout } from 'ink';
+import { themeManager } from '../themes/themeManager';
+
+const shortArt = `
+ ___ ___ ___  ___ _   _ ___ _____ ___  ___  _  _
+/ __|_ _| _ \/ __| | | |_ _|_   _| _ \/ _ \| \| |
+\__ \| ||   / (__| |_| || |  | | |   / (_) | .\` |
+|___/___|_|_\\___|\___/|___| |_| |_|_\\___/|_|\_|
+`;
+
+const longArt = `
+  ____ ___ ____   ____ _   _ ___ _____ ____   ___  _   _
+ / ___|_ _|  _ \ / ___| | | |_ _|_   _|  _ \ / _ \| \ | |
+| |    | || |_) | |   | | | || |  | | | |_) | | | |  \| |
+| |___ | ||  _ <| |___| |_| || |  | | |  _ <| |_| | |\  |
+ \____|___|_| \_\\____|\___/|___| |_| |_| \_\\___/|_| \_|
+`;
+
+export const AsciiArt: React.FC = () => {
+  const { stdout } = useStdout();
+  const width = stdout?.columns ?? 80;
+  const art = width < 80 ? shortArt : longArt;
+  const theme = themeManager.getActive();
+  const warmColors = ['#ff7f50', '#ff8c00', '#ff9d00', '#ff7043', '#ff5722'];
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      {art
+        .trim()
+        .split("\n")
+        .map((line, idx) => (
+          <Text key={idx} color={warmColors[idx % warmColors.length] || theme.Foreground}>
+            {line}
+          </Text>
+        ))}
+    </Box>
+  );
+};
+
+export default AsciiArt;

--- a/packages/cli/src/ui/contexts/BackendContext.tsx
+++ b/packages/cli/src/ui/contexts/BackendContext.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { pingBackend } from '../hooks/useBackend';
+
+export interface BackendState {
+  connected: boolean;
+}
+
+export const BackendContext = React.createContext<BackendState>({
+  connected: false,
+});
+
+interface BackendProviderProps {
+  url: string;
+  children: React.ReactNode;
+}
+
+export const BackendProvider: React.FC<BackendProviderProps> = ({ url, children }) => {
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    pingBackend(url)
+      .then(() => setConnected(true))
+      .catch(() => setConnected(false));
+  }, [url]);
+
+  return (
+    <BackendContext.Provider value={{ connected }}>
+      {children}
+    </BackendContext.Provider>
+  );
+};
+
+export const useBackendContext = () => React.useContext(BackendContext);

--- a/packages/cli/src/ui/hooks/useTheme.ts
+++ b/packages/cli/src/ui/hooks/useTheme.ts
@@ -1,0 +1,9 @@
+import { useSyncExternalStore } from 'react';
+import { themeManager, Theme } from '../themes/themeManager';
+
+export const useTheme = (): Theme => {
+  return useSyncExternalStore(
+    (listener) => themeManager.subscribe(listener),
+    () => themeManager.getActive()
+  );
+};

--- a/packages/cli/src/ui/themes/lightTheme.ts
+++ b/packages/cli/src/ui/themes/lightTheme.ts
@@ -1,0 +1,5 @@
+export const lightTheme = {
+  type: 'light',
+  Background: '#ffffff',
+  Foreground: '#000000',
+};

--- a/packages/cli/src/ui/themes/sunsetTheme.ts
+++ b/packages/cli/src/ui/themes/sunsetTheme.ts
@@ -1,0 +1,5 @@
+export const sunsetTheme = {
+  type: 'sunset',
+  Background: '#2b1b17',
+  Foreground: '#ff9d00',
+};

--- a/packages/cli/src/ui/themes/themeManager.ts
+++ b/packages/cli/src/ui/themes/themeManager.ts
@@ -1,10 +1,39 @@
 import { defaultTheme } from './defaultTheme';
+import { lightTheme } from './lightTheme';
+import { sunsetTheme } from './sunsetTheme';
+
+export type Theme = typeof defaultTheme;
 
 class ThemeManager {
-  private active = defaultTheme;
+  private active: Theme = defaultTheme;
+  private themes: Record<string, Theme> = {
+    dark: defaultTheme,
+    light: lightTheme,
+    sunset: sunsetTheme,
+  };
+  private listeners: Array<() => void> = [];
 
   getActive() {
     return this.active;
+  }
+
+  listThemes() {
+    return Object.keys(this.themes);
+  }
+
+  setActiveTheme(name: string) {
+    const theme = this.themes[name];
+    if (theme) {
+      this.active = theme;
+      this.listeners.forEach((l) => l());
+    }
+  }
+
+  subscribe(listener: () => void) {
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+    };
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,12 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "jsx": "react"
+    "jsx": "react",
+    "types": ["node", "react", "jest"],
+    "baseUrl": "./",
+    "paths": {
+      "ink": ["node_modules/ink/build/index.d.ts"]
+    }
   },
   "include": ["packages/cli/src/**/*"]
 }


### PR DESCRIPTION
## Summary
- tweak README usage notes with theme hint
- add environment-based theme selection
- render new warm-hued "CIRCUITRON" ASCII banner
- provide a sunset theme option

## Testing
- `npm run build`
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6865760d383c8333aedf637633df4123