### PR TITLE
Add themed banner to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ The TUI attempts to connect to `http://localhost:8000` on start. Set
 `CIRCUITRON_BACKEND_URL` to point at a different server.
 Set `CIRCUITRON_THEME` to `dark`, `light`, or `sunset` to change the color
 scheme.
+Use `CIRCUITRON_BANNER_THEME` to choose the ASCII banner gradient. Available
+options are `electric` (default), `solarizedDark`, and `sunset`.
+
+See `assets/ascii_banner.png` for a preview of the banner style.
 
 ### Run the Backend API (Docker)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.6.5",
+        "gradient-string": "^3.0.0",
         "ink": "^4.2.0",
         "react": "^18.3.1"
       },
@@ -1328,6 +1329,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tinycolor2": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
+      "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -2670,6 +2677,19 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gradient-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gradient-string/-/gradient-string-3.0.0.tgz",
+      "integrity": "sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "tinygradient": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5123,6 +5143,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
+    "node_modules/tinygradient": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-1.1.5.tgz",
+      "integrity": "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/tinycolor2": "^1.4.0",
+        "tinycolor2": "^1.0.0"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.6.5",
+    "gradient-string": "^3.0.0",
     "ink": "^4.2.0",
     "react": "^18.3.1"
   },

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -3,7 +3,18 @@ import { render } from 'ink';
 import App from './ui/App';
 import { themeManager } from './ui/themes/themeManager';
 
-const themeName = process.env.CIRCUITRON_THEME || 'dark';
+const argv = process.argv.slice(2);
+const themeArgIndex = argv.indexOf('--theme');
+const bannerThemeArgIndex = argv.indexOf('--banner-theme');
+
+const themeName =
+  (themeArgIndex !== -1 && argv[themeArgIndex + 1]) ||
+  process.env.CIRCUITRON_THEME ||
+  'dark';
 themeManager.setActiveTheme(themeName);
+
+if (bannerThemeArgIndex !== -1 && argv[bannerThemeArgIndex + 1]) {
+  process.env.CIRCUITRON_BANNER_THEME = argv[bannerThemeArgIndex + 1];
+}
 
 render(<App />);

--- a/packages/cli/src/ui/components/AsciiArt.tsx
+++ b/packages/cli/src/ui/components/AsciiArt.tsx
@@ -1,38 +1,28 @@
 import React from 'react';
-import { Text, Box, useStdout } from 'ink';
-import { themeManager } from '../themes/themeManager';
+import { Box, Text } from 'ink';
+import gradient from 'gradient-string';
+import { getBannerColors } from '../themes/bannerThemes';
 
-const shortArt = `
- ___ ___ ___  ___ _   _ ___ _____ ___  ___  _  _
-/ __|_ _| _ \/ __| | | |_ _|_   _| _ \/ _ \| \| |
-\__ \| ||   / (__| |_| || |  | | |   / (_) | .\` |
-|___/___|_|_\\___|\___/|___| |_| |_|_\\___/|_|\_|
-`;
-
-const longArt = `
-  ____ ___ ____   ____ _   _ ___ _____ ____   ___  _   _
- / ___|_ _|  _ \ / ___| | | |_ _|_   _|  _ \ / _ \| \ | |
-| |    | || |_) | |   | | | || |  | | | |_) | | | |  \| |
-| |___ | ||  _ <| |___| |_| || |  | | |  _ <| |_| | |\  |
- \____|___|_| \_\\____|\___/|___| |_| |_| \_\\___/|_| \_|
+const bannerArt = `
+ ██████╗ ██╗██████╗  ██████╗██╗   ██╗██╗████████╗██████╗  ██████╗ ███╗   ██╗
+██╔════╝ ██║██╔══██╗██╔════╝██║   ██║██║╚══██╔══╝██╔══██╗██╔═══██╗████╗  ██║
+██║      ██║██████╔╝██║     ██║   ██║██║   ██║   ██████╔╝██║   ██║██╔██╗ ██║
+██║      ██║██╔══██╗██║     ██║   ██║██║   ██║   ██╔══██╗██║   ██║██║╚██╗██║
+╚██████╗ ██║██║  ██║╚██████╗╚██████╔╝██║   ██║   ██║  ██║╚██████╔╝██║ ╚████║
+ ╚═════╝ ╚═╝╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚═╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝
 `;
 
 export const AsciiArt: React.FC = () => {
-  const { stdout } = useStdout();
-  const width = stdout?.columns ?? 80;
-  const art = width < 80 ? shortArt : longArt;
-  const theme = themeManager.getActive();
-  const warmColors = ['#ff7f50', '#ff8c00', '#ff9d00', '#ff7043', '#ff5722'];
+  const themeName = process.env.CIRCUITRON_BANNER_THEME || 'electric';
+  const colors = getBannerColors(themeName);
 
   return (
     <Box flexDirection="column" marginBottom={1}>
-      {art
+      {bannerArt
         .trim()
-        .split("\n")
+        .split('\n')
         .map((line, idx) => (
-          <Text key={idx} color={warmColors[idx % warmColors.length] || theme.Foreground}>
-            {line}
-          </Text>
+          <Text key={idx}>{gradient(colors)(line)}</Text>
         ))}
     </Box>
   );

--- a/packages/cli/src/ui/themes/bannerThemes.ts
+++ b/packages/cli/src/ui/themes/bannerThemes.ts
@@ -1,0 +1,14 @@
+export type BannerThemeName = 'electric' | 'solarizedDark' | 'sunset';
+
+const themes: Record<BannerThemeName, string[]> = {
+  electric: ['#FFFF66', '#CCFF66', '#66FFCC', '#66CCFF', '#4682B4'],
+  solarizedDark: ['#002B36', '#586E75', '#839496', '#93A1A1', '#EEE8D5'],
+  sunset: ['#FF7E5F', '#FEB47B'],
+};
+
+export function getBannerColors(name: string): string[] {
+  if ((Object.keys(themes) as string[]).includes(name)) {
+    return themes[name as BannerThemeName];
+  }
+  return themes.electric;
+}


### PR DESCRIPTION
## Summary
- add electric, solarizedDark and sunset banner themes
- show gradient banner in the Ink UI
- allow `--banner-theme` CLI flag and `CIRCUITRON_BANNER_THEME` env var
- document banner theme options
- include gradient-string dependency

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865903b003c8333a9c2647e94453fdb