### PR TITLE
Fix GitHub Actions failing due to missing pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install ruff
+          pip install ruff pytest
 
       - name: Lint
         run: ruff check .


### PR DESCRIPTION
## Summary
- install `pytest` during CI setup so tests run

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865a4adfbd883339a5011ff393aacf9