### PR TITLE
Ensure DockerSession cleanup

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -5,6 +5,7 @@ from .config import setup_environment
 from .models import CodeGenerationOutput
 
 
+
 async def run_circuitron(
     prompt: str, show_reasoning: bool = False, debug: bool = False
 ) -> CodeGenerationOutput:
@@ -18,14 +19,19 @@ def main() -> None:
     """Main entry point for the Circuitron system."""
     setup_environment()
     from circuitron.pipeline import parse_args
+    from circuitron.tools import kicad_session
 
     args = parse_args()
     prompt = args.prompt or input("Prompt: ")
     show_reasoning = args.reasoning
     debug = args.debug
-    
-    # Execute pipeline
-    code_output = asyncio.run(run_circuitron(prompt, show_reasoning, debug))
+
+    code_output: CodeGenerationOutput | None = None
+    try:
+        code_output = asyncio.run(run_circuitron(prompt, show_reasoning, debug))
+    finally:
+        kicad_session.stop()
+
     if code_output:
         print("\n=== GENERATED SKiDL CODE ===\n")
         print(code_output.complete_skidl_code)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ def test_cli_main_uses_args_and_prints(capsys):
     args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
-         patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)):
+        patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)):
         cli.main()
     captured = capsys.readouterr().out
     assert "GENERATED SKiDL CODE" in captured
@@ -47,3 +47,14 @@ def test_module_main_called():
     with patch("circuitron.cli.main") as main_mock:
         runpy.run_module("circuitron", run_name="__main__")
         main_mock.assert_called_once()
+
+
+def test_cli_main_stops_session():
+    out = CodeGenerationOutput(complete_skidl_code="123")
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
+    with patch("circuitron.cli.setup_environment"), \
+         patch("circuitron.pipeline.parse_args", return_value=args), \
+         patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)), \
+         patch("circuitron.tools.kicad_session.stop") as stop_mock:
+        cli.main()
+        stop_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- guarantee KiCad Docker container stops after running the CLI
- test that `main` triggers session cleanup

## Testing
- `ruff check .`
- `mypy --strict circuitron`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c5d32ee08333b95fdd3b3cd0d133