### PR TITLE
Handle KeyboardInterrupt gracefully

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -28,7 +28,12 @@ def main() -> None:
 
     code_output: CodeGenerationOutput | None = None
     try:
-        code_output = asyncio.run(run_circuitron(prompt, show_reasoning, debug))
+        try:
+            code_output = asyncio.run(
+                run_circuitron(prompt, show_reasoning, debug)
+            )
+        except KeyboardInterrupt:
+            print("\nExecution interrupted by user.")
     finally:
         kicad_session.stop()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,3 +58,15 @@ def test_cli_main_stops_session():
          patch("circuitron.tools.kicad_session.stop") as stop_mock:
         cli.main()
         stop_mock.assert_called_once()
+
+def test_cli_main_handles_keyboardinterrupt(capsys):
+    import circuitron.config as cfg
+    cfg.setup_environment()
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
+    with patch("circuitron.cli.setup_environment"), \
+         patch("circuitron.pipeline.parse_args", return_value=args), \
+         patch("circuitron.cli.run_circuitron", AsyncMock(side_effect=KeyboardInterrupt)), \
+         patch("circuitron.tools.kicad_session.stop"):
+        cli.main()
+    captured = capsys.readouterr().out
+    assert "interrupted" in captured.lower()


### PR DESCRIPTION
## Summary
- catch `KeyboardInterrupt` in the CLI to notify user and ensure cleanup
- test that the CLI prints a friendly message on `Ctrl+C`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ca743adc83338c1de5e9a2addc69