### PR TITLE
Ensure env vars set before OpenAI calls

### DIFF
--- a/circuitron/config.py
+++ b/circuitron/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import sys
 import logfire
 from dotenv import load_dotenv
 
@@ -11,8 +13,17 @@ settings: Settings
 
 
 def setup_environment() -> None:
-    """Initialize environment variables and configure logging/tracing."""
+    """Initialize environment variables and configure logging/tracing.
+
+    Exits the program if required variables are missing.
+    """
     load_dotenv()
+
+    required = ["OPENAI_API_KEY", "MCP_URL"]
+    missing = [var for var in required if not os.getenv(var)]
+    if missing:
+        msg = ", ".join(missing)
+        sys.exit(f"Missing required environment variables: {msg}")
     logfire.configure()
     logfire.instrument_openai_agents()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("MCP_URL", "http://localhost:8051")
+
+@pytest.fixture(autouse=True)
+def _set_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("MCP_URL", "http://localhost:8051")
+    yield
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,12 @@
+import pytest
+
+import circuitron.config as cfg
+
+
+def test_setup_environment_requires_vars(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("MCP_URL", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        cfg.setup_environment()
+    assert "Missing required environment variables" in str(exc.value)
+


### PR DESCRIPTION
## Summary
- fail fast if essential variables like `OPENAI_API_KEY` or `MCP_URL` are missing
- preset required env vars for the test suite
- test `setup_environment()` exits when variables are absent

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d7332c2883338400619fdbeca756