### PR TITLE
Fix mypy errors in tests

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,7 +1,8 @@
 import importlib
+import pytest
 
 
-def test_agent_models_from_env(monkeypatch):
+def test_agent_models_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
@@ -21,7 +22,7 @@ def test_agent_models_from_env(monkeypatch):
     assert mod.code_generator.model == "c-model"
 
 
-def test_partfinder_includes_footprint_tool():
+def test_partfinder_includes_footprint_tool() -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
@@ -31,7 +32,7 @@ def test_partfinder_includes_footprint_tool():
     assert "search_kicad_footprints" in tool_names
 
 
-def test_partselector_includes_pin_tool():
+def test_partselector_includes_pin_tool() -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
@@ -41,7 +42,7 @@ def test_partselector_includes_pin_tool():
     assert "extract_pin_details" in tool_names
 
 
-def test_documentation_agent_has_mcp_tool():
+def test_documentation_agent_has_mcp_tool() -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
@@ -50,7 +51,7 @@ def test_documentation_agent_has_mcp_tool():
     assert any(tool.__class__.__name__ == "HostedMCPTool" for tool in mod.documentation.tools)
 
 
-def test_code_generation_agent_has_mcp_tool():
+def test_code_generation_agent_has_mcp_tool() -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
@@ -59,7 +60,7 @@ def test_code_generation_agent_has_mcp_tool():
     assert any(tool.__class__.__name__ == "HostedMCPTool" for tool in mod.code_generator.tools)
 
 
-def test_code_corrector_configuration():
+def test_code_corrector_configuration() -> None:
     import sys
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,22 +4,23 @@ from unittest.mock import AsyncMock, patch
 
 import circuitron.cli as cli
 from circuitron.models import CodeGenerationOutput
+import pytest
 
 
-def test_run_circuitron_invokes_pipeline():
+def test_run_circuitron_invokes_pipeline() -> None:
     out = CodeGenerationOutput(complete_skidl_code="code")
-    async def fake_pipeline(prompt: str, show_reasoning: bool = False, debug: bool = False):
+    async def fake_pipeline(prompt: str, show_reasoning: bool = False, debug: bool = False) -> CodeGenerationOutput:
         assert prompt == "p"
         assert show_reasoning is True
         assert debug is False
         return out
 
     with patch("circuitron.pipeline.pipeline", AsyncMock(side_effect=fake_pipeline)):
-        result = asyncio.run(cli.run_circuitron("p", show_reasoning=True))
+        result: CodeGenerationOutput = asyncio.run(cli.run_circuitron("p", show_reasoning=True))
     assert result is out
 
 
-def test_cli_main_uses_args_and_prints(capsys):
+def test_cli_main_uses_args_and_prints(capsys: pytest.CaptureFixture[str]) -> None:
     out = CodeGenerationOutput(complete_skidl_code="abc")
     args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
     with patch("circuitron.cli.setup_environment"), \
@@ -31,7 +32,7 @@ def test_cli_main_uses_args_and_prints(capsys):
     assert "abc" in captured
 
 
-def test_cli_main_prompts_for_input(monkeypatch):
+def test_cli_main_prompts_for_input(monkeypatch: pytest.MonkeyPatch) -> None:
     out = CodeGenerationOutput(complete_skidl_code="xyz")
     args = SimpleNamespace(prompt=None, reasoning=True, debug=True)
     with patch("circuitron.cli.setup_environment"), \
@@ -42,14 +43,14 @@ def test_cli_main_prompts_for_input(monkeypatch):
         run_mock.assert_awaited_with("hello", True, True)
 
 
-def test_module_main_called():
+def test_module_main_called() -> None:
     import runpy
     with patch("circuitron.cli.main") as main_mock:
         runpy.run_module("circuitron", run_name="__main__")
         main_mock.assert_called_once()
 
 
-def test_cli_main_stops_session():
+def test_cli_main_stops_session() -> None:
     out = CodeGenerationOutput(complete_skidl_code="123")
     args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
     with patch("circuitron.cli.setup_environment"), \
@@ -59,7 +60,7 @@ def test_cli_main_stops_session():
         cli.main()
         stop_mock.assert_called_once()
 
-def test_cli_main_handles_keyboardinterrupt(capsys):
+def test_cli_main_handles_keyboardinterrupt(capsys: pytest.CaptureFixture[str]) -> None:
     import circuitron.config as cfg
     cfg.setup_environment()
     args = SimpleNamespace(prompt="p", reasoning=False, debug=False)

--- a/tests/test_code_generation.py
+++ b/tests/test_code_generation.py
@@ -3,7 +3,7 @@ from circuitron.models import CodeGenerationOutput
 from circuitron.utils import validate_code_generation_results
 
 
-def test_validate_code_generation_results():
+def test_validate_code_generation_results() -> None:
     cfg.setup_environment()
     out = CodeGenerationOutput(complete_skidl_code="from skidl import *\n")
     assert validate_code_generation_results(out) is True

--- a/tests/test_docker_session.py
+++ b/tests/test_docker_session.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from circuitron.docker_session import DockerSession
 
 
-def test_reuse_running_container():
+def test_reuse_running_container() -> None:
     session = DockerSession("img", "cont")
     proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="Up 3s\n", stderr="")
     with patch.object(session, "_run", return_value=proc) as run_mock:
@@ -14,7 +14,7 @@ def test_reuse_running_container():
         assert run_mock.call_args.args[0][:3] == ["docker", "ps", "-a"]
 
 
-def test_remove_exited_container():
+def test_remove_exited_container() -> None:
     session = DockerSession("img", "cont")
     ps_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="Exited (0) 1s\n", stderr="")
     rm_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
@@ -27,7 +27,7 @@ def test_remove_exited_container():
         assert run_mock.call_args_list[2].args[0][0] == "docker" and run_mock.call_args_list[2].args[0][1] == "run"
 
 
-def test_start_logs_failure():
+def test_start_logs_failure() -> None:
     session = DockerSession("img", "cont")
     ps_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
     err = subprocess.CalledProcessError(returncode=1, cmd=["docker"], stderr="boom")

--- a/tests/test_format_input.py
+++ b/tests/test_format_input.py
@@ -13,7 +13,7 @@ from circuitron.utils import (
 )
 
 
-def test_format_plan_edit_input_includes_sections():
+def test_format_plan_edit_input_includes_sections() -> None:
     plan = PlanOutput(
         design_rationale=["Reason"],
         functional_blocks=["Block"],
@@ -33,7 +33,7 @@ def test_format_plan_edit_input_includes_sections():
     assert "Answers to Open Questions:" in text
 
 
-def test_format_documentation_input_includes_parts():
+def test_format_documentation_input_includes_parts() -> None:
     plan = PlanOutput(functional_blocks=["Block"], implementation_actions=["Do"])
     pin = PinDetail(number="1", name="VCC", function="POWER-IN")
     part = SelectedPart(name="U1", library="lib", pin_details=[pin])
@@ -44,7 +44,7 @@ def test_format_documentation_input_includes_parts():
     assert "pin 1: VCC" in text
 
 
-def test_format_code_generation_input_includes_docs():
+def test_format_code_generation_input_includes_docs() -> None:
     plan = PlanOutput(functional_blocks=["Block"], implementation_actions=["Do"])
     pin = PinDetail(number="1", name="VCC", function="POWER-IN")
     part = SelectedPart(name="U1", library="lib", pin_details=[pin])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,26 +14,26 @@ from circuitron.models import (
 )
 
 
-def test_plan_editor_output_edit():
+def test_plan_editor_output_edit() -> None:
     plan = PlanOutput()
     decision = PlanEditDecision(action="edit_plan", reasoning="ok")
     result = PlanEditorOutput(decision=decision, updated_plan=plan)
     assert result.updated_plan is plan
 
 
-def test_plan_editor_output_edit_missing_plan():
+def test_plan_editor_output_edit_missing_plan() -> None:
     decision = PlanEditDecision(action="edit_plan", reasoning="bad")
     with pytest.raises(ValueError):
         PlanEditorOutput(decision=decision)
 
 
-def test_plan_editor_output_regenerate():
+def test_plan_editor_output_regenerate() -> None:
     decision = PlanEditDecision(action="regenerate_plan", reasoning="redo")
     result = PlanEditorOutput(decision=decision, reconstructed_prompt="new")
     assert result.reconstructed_prompt == "new"
 
 
-def test_documentation_output():
+def test_documentation_output() -> None:
     out = DocumentationOutput(
         research_queries=["q"],
         documentation_findings=["f"],
@@ -42,7 +42,7 @@ def test_documentation_output():
     assert out.implementation_readiness == "ready"
 
 
-def test_code_generation_output():
+def test_code_generation_output() -> None:
     out = CodeGenerationOutput(
         complete_skidl_code="from skidl import *\n",
         imports=["from skidl import *"],
@@ -50,7 +50,7 @@ def test_code_generation_output():
     assert "skidl" in out.complete_skidl_code
 
 
-def test_code_validation_output():
+def test_code_validation_output() -> None:
     issue = ValidationIssue(line=1, category="syntax", message="bad")
     summary = ValidationSummary(
         total_validations=1,

--- a/tests/test_part_selection.py
+++ b/tests/test_part_selection.py
@@ -18,7 +18,7 @@ from circuitron.models import (
 cfg.setup_environment()
 
 
-async def fake_pipeline_no_feedback():
+async def fake_pipeline_no_feedback() -> None:
     import circuitron.pipeline as pl
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -39,7 +39,7 @@ async def fake_pipeline_no_feedback():
     assert result is code_out
 
 
-async def fake_pipeline_edit_plan():
+async def fake_pipeline_edit_plan() -> None:
     import circuitron.pipeline as pl
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -66,7 +66,7 @@ async def fake_pipeline_edit_plan():
     assert result is code_out
 
 
-def test_pipeline_asyncio():
+def test_pipeline_asyncio() -> None:
     asyncio.run(fake_pipeline_no_feedback())
     asyncio.run(fake_pipeline_edit_plan())
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,5 +1,6 @@
 import asyncio
 from types import SimpleNamespace
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from circuitron.models import (
@@ -18,7 +19,7 @@ import circuitron.config as cfg
 cfg.setup_environment()
 
 
-async def fake_pipeline_no_feedback():
+async def fake_pipeline_no_feedback() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=[])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -39,7 +40,7 @@ async def fake_pipeline_no_feedback():
     assert result is code_out
 
 
-async def fake_pipeline_edit_plan():
+async def fake_pipeline_edit_plan() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=[])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -66,12 +67,12 @@ async def fake_pipeline_edit_plan():
     assert result is code_out
 
 
-def test_pipeline_asyncio():
+def test_pipeline_asyncio() -> None:
     asyncio.run(fake_pipeline_no_feedback())
     asyncio.run(fake_pipeline_edit_plan())
 
 
-def test_parse_args():
+def test_parse_args() -> None:
     from circuitron import pipeline as pl
     args = pl.parse_args(["prompt", "-r", "-d"])
     assert args.prompt == "prompt"
@@ -79,7 +80,7 @@ def test_parse_args():
     assert args.debug is True
 
 
-def test_run_code_validation_calls_erc():
+def test_run_code_validation_calls_erc() -> None:
     import circuitron.pipeline as pl
     code_out = CodeGenerationOutput(complete_skidl_code="from skidl import *")
     selection = PartSelectionOutput()
@@ -92,10 +93,11 @@ def test_run_code_validation_calls_erc():
             erc_mock.assert_called_once()
     validation, erc = result
     assert validation.status == "pass"
+    assert erc is not None
     assert erc["erc_passed"] is True
 
 
-def test_run_code_validation_no_erc_on_fail():
+def test_run_code_validation_no_erc_on_fail() -> None:
     import circuitron.pipeline as pl
     code_out = CodeGenerationOutput(complete_skidl_code="from skidl import *")
     selection = PartSelectionOutput()
@@ -111,7 +113,7 @@ def test_run_code_validation_no_erc_on_fail():
     assert erc is None
 
 
-async def fake_pipeline_with_correction():
+async def fake_pipeline_with_correction() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput()
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -135,12 +137,12 @@ async def fake_pipeline_with_correction():
     assert result.complete_skidl_code == "fixed"
 
 
-def test_pipeline_correction_flow():
+def test_pipeline_correction_flow() -> None:
     asyncio.run(fake_pipeline_with_correction())
 
 
 
-async def fake_pipeline_debug_show():
+async def fake_pipeline_debug_show() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=["print(1)"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -159,10 +161,10 @@ async def fake_pipeline_debug_show():
     assert result is code_out
 
 
-def test_pipeline_debug_show_flow():
+def test_pipeline_debug_show_flow() -> None:
     asyncio.run(fake_pipeline_debug_show())
 
-async def fake_pipeline_edit_plan_with_correction():
+async def fake_pipeline_edit_plan_with_correction() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -191,10 +193,10 @@ async def fake_pipeline_edit_plan_with_correction():
     assert result.complete_skidl_code == "fixed"
 
 
-def test_pipeline_edit_plan_with_correction():
+def test_pipeline_edit_plan_with_correction() -> None:
     asyncio.run(fake_pipeline_edit_plan_with_correction())
 
-async def fake_pipeline_regen_with_correction():
+async def fake_pipeline_regen_with_correction() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput()
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
@@ -224,11 +226,11 @@ async def fake_pipeline_regen_with_correction():
     assert result.complete_skidl_code == "fixed"
 
 
-def test_pipeline_regen_with_correction():
+def test_pipeline_regen_with_correction() -> None:
     asyncio.run(fake_pipeline_regen_with_correction())
 
 
-def test_run_code_validation_cleanup(tmp_path):
+def test_run_code_validation_cleanup(tmp_path: Path) -> None:
     import circuitron.pipeline as pl
 
     code_out = CodeGenerationOutput(complete_skidl_code="from skidl import *")
@@ -250,7 +252,7 @@ def test_run_code_validation_cleanup(tmp_path):
     assert not script_path.exists()
 
 
-def test_run_code_correction_cleanup(tmp_path):
+def test_run_code_correction_cleanup(tmp_path: Path) -> None:
     import circuitron.pipeline as pl
 
     code_out = CodeGenerationOutput(complete_skidl_code="from skidl import *")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,13 +1,14 @@
 import asyncio
 import json
 import subprocess
+from typing import Any, Coroutine, cast
 from unittest.mock import patch
 
 from agents.tool_context import ToolContext
 import circuitron.config as cfg
 
 
-def test_search_kicad_libraries():
+def test_search_kicad_libraries() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_libraries
     fake_output = '[{"name": "LM324", "library": "linear", "footprint": "DIP-14", "description": "op amp"}]'
@@ -15,13 +16,13 @@ def test_search_kicad_libraries():
     with patch("circuitron.tools.kicad_session.exec_python", return_value=completed) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t1")
         args = json.dumps({"query": "opamp lm324"})
-        result = asyncio.run(search_kicad_libraries.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_libraries.on_invoke_tool(ctx, args)))
         data = json.loads(result)
         assert data[0]["name"] == "LM324"
         run_mock.assert_called_once()
 
 
-def test_search_kicad_libraries_timeout():
+def test_search_kicad_libraries_timeout() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_libraries
     with patch(
@@ -30,11 +31,11 @@ def test_search_kicad_libraries_timeout():
     ):
         ctx = ToolContext(context=None, tool_call_id="t2")
         args = json.dumps({"query": "123"})
-        result = asyncio.run(search_kicad_libraries.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_libraries.on_invoke_tool(ctx, args)))
         assert "error" in result.lower()
 
 
-def test_search_kicad_footprints():
+def test_search_kicad_footprints() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_footprints
     fake_output = '[{"name": "SOIC-8", "library": "Package_SO", "description": "soic"}]'
@@ -42,13 +43,13 @@ def test_search_kicad_footprints():
     with patch("circuitron.tools.kicad_session.exec_python", return_value=completed) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t3")
         args = json.dumps({"query": "SOIC-8"})
-        result = asyncio.run(search_kicad_footprints.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_footprints.on_invoke_tool(ctx, args)))
         data = json.loads(result)
         assert data[0]["name"] == "SOIC-8"
         run_mock.assert_called_once()
 
 
-def test_search_kicad_footprints_timeout():
+def test_search_kicad_footprints_timeout() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_footprints
     with patch(
@@ -57,11 +58,11 @@ def test_search_kicad_footprints_timeout():
     ):
         ctx = ToolContext(context=None, tool_call_id="t4")
         args = json.dumps({"query": "DIP"})
-        result = asyncio.run(search_kicad_footprints.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_footprints.on_invoke_tool(ctx, args)))
         assert "error" in result.lower()
 
 
-def test_extract_pin_details():
+def test_extract_pin_details() -> None:
     cfg.setup_environment()
     from circuitron.tools import extract_pin_details
     fake_output = '[{"number": "1", "name": "VCC", "function": "POWER"}]'
@@ -69,13 +70,13 @@ def test_extract_pin_details():
     with patch("circuitron.tools.kicad_session.exec_python", return_value=completed) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t5")
         args = json.dumps({"library": "linear", "part_name": "lm386"})
-        result = asyncio.run(extract_pin_details.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(cast(Coroutine[Any, Any, str], extract_pin_details.on_invoke_tool(ctx, args)))
         data = json.loads(result)
         assert data[0]["name"] == "VCC"
         run_mock.assert_called_once()
 
 
-def test_extract_pin_details_timeout():
+def test_extract_pin_details_timeout() -> None:
     cfg.setup_environment()
     from circuitron.tools import extract_pin_details
     with patch(
@@ -84,11 +85,11 @@ def test_extract_pin_details_timeout():
     ):
         ctx = ToolContext(context=None, tool_call_id="t6")
         args = json.dumps({"library": "lin", "part_name": "bad"})
-        result = asyncio.run(extract_pin_details.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(cast(Coroutine[Any, Any, str], extract_pin_details.on_invoke_tool(ctx, args)))
         assert "error" in result.lower()
 
 
-def test_create_mcp_documentation_tools():
+def test_create_mcp_documentation_tools() -> None:
     cfg.setup_environment()
     from circuitron.tools import create_mcp_documentation_tools
 
@@ -99,7 +100,7 @@ def test_create_mcp_documentation_tools():
         assert tools == [dummy_tool]
 
 
-def test_create_mcp_validation_tools():
+def test_create_mcp_validation_tools() -> None:
     cfg.setup_environment()
     from circuitron.tools import create_mcp_validation_tools
 
@@ -110,7 +111,7 @@ def test_create_mcp_validation_tools():
         assert tools == [dummy_tool]
 
 
-def test_run_erc_success():
+def test_run_erc_success() -> None:
     cfg.setup_environment()
     from circuitron.tools import run_erc
 
@@ -118,12 +119,12 @@ def test_run_erc_success():
     with patch("circuitron.tools.kicad_session.exec_erc", return_value=completed) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t7")
         args = json.dumps({"script_path": "/tmp/a.py"})
-        result = asyncio.run(run_erc.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(cast(Coroutine[Any, Any, str], run_erc.on_invoke_tool(ctx, args)))
         assert "{}" in result
         run_mock.assert_called_once()
 
 
-def test_run_erc_timeout():
+def test_run_erc_timeout() -> None:
     cfg.setup_environment()
     from circuitron.tools import run_erc
 
@@ -133,11 +134,11 @@ def test_run_erc_timeout():
     ):
         ctx = ToolContext(context=None, tool_call_id="t8")
         args = json.dumps({"script_path": "/tmp/a.py"})
-        result = asyncio.run(run_erc.on_invoke_tool(ctx, args))
+        result: str = asyncio.run(cast(Coroutine[Any, Any, str], run_erc.on_invoke_tool(ctx, args)))
         assert "success" in result
 
 
-def test_kicad_session_start_once():
+def test_kicad_session_start_once() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_libraries, kicad_session
 
@@ -149,8 +150,8 @@ def test_kicad_session_start_once():
     with patch.object(kicad_session, "_run", return_value=fake_proc) as _run_mock, patch.object(kicad_session, "start", side_effect=fake_start) as start_mock:
         ctx = ToolContext(context=None, tool_call_id="t9")
         args = json.dumps({"query": "foo"})
-        asyncio.run(search_kicad_libraries.on_invoke_tool(ctx, args))
-        asyncio.run(search_kicad_libraries.on_invoke_tool(ctx, args))
+        asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_libraries.on_invoke_tool(ctx, args)))
+        asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_libraries.on_invoke_tool(ctx, args)))
         assert start_mock.call_count == 2
         assert _run_mock.call_count == 2
     kicad_session.started = False

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -1,7 +1,12 @@
 import os
 from types import SimpleNamespace
+from pathlib import Path
+from typing import Any, cast
+import pytest
 
 from agents.items import ReasoningItem
+from agents.agent import Agent
+from agents.result import RunResult
 from openai.types.responses.response_reasoning_item import ResponseReasoningItem, Summary
 
 from circuitron.models import (
@@ -9,6 +14,7 @@ from circuitron.models import (
     PlanOutput,
     AnalysisMetadata,
     CodeValidationOutput,
+    DocumentationOutput,
     HallucinationReport,
     PartSelectionOutput,
     PinDetail,
@@ -34,15 +40,15 @@ from circuitron.utils import (
 )
 
 
-def test_extract_reasoning_summary():
+def test_extract_reasoning_summary() -> None:
     summary = Summary(text="explain", type="summary_text")
     rr = ResponseReasoningItem(id="1", summary=[summary], type="reasoning")
-    item = ReasoningItem(agent=SimpleNamespace(), raw_item=rr)
-    result = extract_reasoning_summary(SimpleNamespace(new_items=[item]))
+    item = ReasoningItem(agent=cast(Agent[Any], SimpleNamespace()), raw_item=rr)
+    result = extract_reasoning_summary(cast(RunResult, SimpleNamespace(new_items=[item])))
     assert "explain" in result
 
 
-def test_write_temp_skidl_script(tmp_path):
+def test_write_temp_skidl_script(tmp_path: Path) -> None:
     path = write_temp_skidl_script("print('hi')")
     assert os.path.exists(path)
     with open(path) as fh:
@@ -51,7 +57,7 @@ def test_write_temp_skidl_script(tmp_path):
     os.remove(path)
 
 
-def test_parse_hallucination_report_roundtrip():
+def test_parse_hallucination_report_roundtrip() -> None:
     summary = ValidationSummary(
         total_validations=1,
         valid_count=1,
@@ -83,11 +89,11 @@ def test_parse_hallucination_report_roundtrip():
     assert parsed.validation_summary.valid_count == 1
 
 
-def test_format_code_validation_and_correction_input():
+def test_format_code_validation_and_correction_input() -> None:
     pin = PinDetail(number="1", name="VCC", function="pwr")
     part = SelectedPart(name="U1", library="lib", footprint="fp", pin_details=[pin])
     selection = PartSelectionOutput(selections=[part])
-    docs = SimpleNamespace(documentation_findings=["doc"])
+    docs = cast(DocumentationOutput, SimpleNamespace(documentation_findings=["doc"]))
     val = CodeValidationOutput(status="fail", summary="bad", issues=[ValidationIssue(category="err", message="m", line=1)])
     text = format_code_validation_input("/tmp/s.py", selection, docs)
     assert "s.py" in text and "U1" in text and "doc" in text
@@ -95,7 +101,7 @@ def test_format_code_validation_and_correction_input():
     assert "Validation Summary: bad" in corr
     assert "erc_passed" in corr
 
-def test_pretty_print_helpers(capsys):
+def test_pretty_print_helpers(capsys: pytest.CaptureFixture[str]) -> None:
     from circuitron.models import PlanEditDecision, PlanEditorOutput, PlanOutput, DocumentationOutput
     plan = PlanOutput(
         design_rationale=["why"],
@@ -125,7 +131,7 @@ def test_pretty_print_helpers(capsys):
     out = capsys.readouterr().out
     assert "SELECTED COMPONENTS" in out
 
-def test_collect_user_feedback(monkeypatch):
+def test_collect_user_feedback(monkeypatch: pytest.MonkeyPatch) -> None:
     plan = PlanOutput(design_limitations=["q"], component_search_queries=[])
     answers = iter(["ans", "edit1", "", "req1", ""])
     monkeypatch.setattr("builtins.input", lambda _: next(answers))


### PR DESCRIPTION
## Summary
- add missing type hints across test modules
- tighten typed test calls using `cast`
- assert ERC result non-None in pipeline test

## Testing
- `poetry run mypy --strict circuitron tests`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'circuitron')*

------
https://chatgpt.com/codex/tasks/task_e_6866d717899c83338c98ed7998d5add4