### PR TITLE
Fix README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ See [overview.md](overview.md) for detailed project goals and structure.
 
 ### Setup
 
-Install dependencies with `pip install -r requirements.txt` and install the
-package so the CLI and tests can run:
+Install dependencies directly from `pyproject.toml` and install the package so
+the CLI and tests can run:
 
 ```bash
 pip install -e .  # or `pip install .`
 ```
+
+This installs `openai-agents`, `python-dotenv`, `skidl`, and `logfire`.
+A matching `requirements.txt` is included for convenience.
 
 Copy `.env.example` to `.env` and fill in the required values:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai-agents==0.1.0
+python-dotenv>=1.1.0
+skidl>=2.0.1
+logfire>=3.22.0


### PR DESCRIPTION
## Summary
- clarify installation steps in README to use `pip install -e .`
- add explicit list of dependencies
- create requirements.txt matching pyproject

## Testing
- `ruff check .`
- `mypy circuitron`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866dd2a5ed08333a21da067e43c592d