### PR TITLE
Validate required env vars

### DIFF
--- a/circuitron/config.py
+++ b/circuitron/config.py
@@ -19,7 +19,13 @@ def setup_environment() -> None:
     """
     load_dotenv()
 
-    required = ["OPENAI_API_KEY", "MCP_URL"]
+    required = [
+        "OPENAI_API_KEY",
+        "PLANNING_MODEL",
+        "PLAN_EDIT_MODEL",
+        "PART_FINDER_MODEL",
+        "MCP_URL",
+    ]
     missing = [var for var in required if not os.getenv(var)]
     if missing:
         msg = ", ".join(missing)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,17 @@ import os
 import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("PLANNING_MODEL", "test-model")
+os.environ.setdefault("PLAN_EDIT_MODEL", "test-model")
+os.environ.setdefault("PART_FINDER_MODEL", "test-model")
 os.environ.setdefault("MCP_URL", "http://localhost:8051")
 
 @pytest.fixture(autouse=True)
 def _set_env(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("PLANNING_MODEL", "test-model")
+    monkeypatch.setenv("PLAN_EDIT_MODEL", "test-model")
+    monkeypatch.setenv("PART_FINDER_MODEL", "test-model")
     monkeypatch.setenv("MCP_URL", "http://localhost:8051")
     yield
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,8 +5,19 @@ import circuitron.config as cfg
 
 def test_setup_environment_requires_vars(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("PLANNING_MODEL", raising=False)
+    monkeypatch.delenv("PLAN_EDIT_MODEL", raising=False)
+    monkeypatch.delenv("PART_FINDER_MODEL", raising=False)
     monkeypatch.delenv("MCP_URL", raising=False)
     with pytest.raises(SystemExit) as exc:
         cfg.setup_environment()
-    assert "Missing required environment variables" in str(exc.value)
+    message = str(exc.value)
+    for var in [
+        "OPENAI_API_KEY",
+        "PLANNING_MODEL",
+        "PLAN_EDIT_MODEL",
+        "PART_FINDER_MODEL",
+        "MCP_URL",
+    ]:
+        assert var in message
 


### PR DESCRIPTION
## Summary
- validate additional environment variables in `setup_environment`
- default those variables in the test suite
- verify missing variable message lists each missing name

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866dd37c9c08333bd556f0853e05035