### PR TITLE
Use asyncio.to_thread for subprocess calls

### DIFF
--- a/circuitron/config.py
+++ b/circuitron/config.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 
 from .settings import Settings
 
-settings: Settings
+settings = Settings()
 
 
 def setup_environment() -> None:

--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -6,6 +6,7 @@ Contains calculation tools and other utilities that agents can use.
 
 from agents import function_tool
 from agents.tool import HostedMCPTool, Tool
+import asyncio
 import subprocess
 import textwrap
 import json
@@ -51,8 +52,13 @@ async def execute_calculation(
         safe_code,
     ]
     try:
-        proc = subprocess.run(
-            docker_cmd, capture_output=True, text=True, timeout=15, check=True
+        proc = await asyncio.to_thread(
+            subprocess.run,
+            docker_cmd,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=True,
         )
     except subprocess.TimeoutExpired as exc:
         return CalcResult(calculation_id=calculation_id, success=False, stderr=str(exc))
@@ -89,7 +95,9 @@ if parts:
 print(json.dumps(results))
 """)
     try:
-        proc = kicad_session.exec_python(script, timeout=120)
+        proc = await asyncio.to_thread(
+            kicad_session.exec_python, script, timeout=120
+        )
     except subprocess.TimeoutExpired as exc:
         return json.dumps({"error": "search timeout", "details": str(exc)})
     except subprocess.CalledProcessError as exc:
@@ -114,7 +122,9 @@ if footprints:
 print(json.dumps(results))
 """)
     try:
-        proc = kicad_session.exec_python(script, timeout=120)
+        proc = await asyncio.to_thread(
+            kicad_session.exec_python, script, timeout=120
+        )
     except subprocess.TimeoutExpired as exc:
         return json.dumps({"error": "footprint search timeout", "details": str(exc)})
     except subprocess.CalledProcessError as exc:
@@ -150,7 +160,9 @@ print(json.dumps(pins))
 """
     )
     try:
-        proc = kicad_session.exec_python(script, timeout=120)
+        proc = await asyncio.to_thread(
+            kicad_session.exec_python, script, timeout=120
+        )
     except subprocess.TimeoutExpired as exc:
         return json.dumps({"error": "pin extract timeout", "details": str(exc)})
     except subprocess.CalledProcessError as exc:
@@ -215,7 +227,9 @@ async def run_erc(script_path: str) -> str:
         """
     )
     try:
-        proc = kicad_session.exec_erc(script_path, wrapper)
+        proc = await asyncio.to_thread(
+            kicad_session.exec_erc, script_path, wrapper
+        )
     except subprocess.TimeoutExpired as exc:
         return json.dumps({'success': False, 'erc_passed': False, 'stdout': '', 'stderr': str(exc)})
     except subprocess.CalledProcessError as exc:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
 import os
+from typing import Iterator
+
 import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 os.environ.setdefault("MCP_URL", "http://localhost:8051")
 
 @pytest.fixture(autouse=True)
-def _set_env(monkeypatch):
+def _set_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setenv("MCP_URL", "http://localhost:8051")
     yield

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ import pytest
 import circuitron.config as cfg
 
 
-def test_setup_environment_requires_vars(monkeypatch):
+def test_setup_environment_requires_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("MCP_URL", raising=False)
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Summary
- prevent event loop blocking by running subprocess operations in a thread
- update config to initialize `settings` on import
- remove duplicate helpers from the prototype example
- type annotate fixtures and tests

## Testing
- `ruff check .`
- `mypy --strict . | tail -n 20`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866dd329b88833394a6995318aaeeee