### PR TITLE
Handle Docker start failures

### DIFF
--- a/circuitron/docker_session.py
+++ b/circuitron/docker_session.py
@@ -65,11 +65,20 @@ class DockerSession:
         ]
         try:
             self._run(cmd, check=True)
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        except subprocess.CalledProcessError as exc:
             logging.error(
                 "Failed to start container %s: %s",
                 self.container_name,
-                getattr(exc, "stderr", str(exc)).strip(),
+                exc.stderr.strip(),
+            )
+            raise RuntimeError(
+                "Failed to start Docker container. Ensure Docker is installed and that the current user has permission to run containers."
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            logging.error(
+                "Failed to start container %s: %s",
+                self.container_name,
+                str(exc).strip(),
             )
             raise
         self.started = True


### PR DESCRIPTION
## Summary
- raise a helpful `RuntimeError` when the Docker container fails to start
- verify the error path in `test_docker_session`

## Testing
- `python -m pytest tests/test_docker_session.py::test_start_logs_failure -q`
- `python -m pytest tests/test_docker_session.py::test_start_error_message -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866e38beafc8333bbefbb444ac7354c