### PR TITLE
Update README with test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ circuitron/
 ├── lib_pickle_dir/         # Cached KiCad component libraries
 └── tests/                  # Test suite
 
+## Running Tests
+
+Install the package in editable mode so the CLI and tests use the local sources:
+
+```bash
+pip install -e .  # or `pip install .`
+pytest -q
+```
+
+All tests should pass after installation.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- add a Running Tests section to the README describing how to install the package before running pytest

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866e6ef80408333b4b4e8cdca1e841d