### PR TITLE
Ensure settings updated in-place

### DIFF
--- a/circuitron/config.py
+++ b/circuitron/config.py
@@ -12,7 +12,7 @@ from .settings import Settings
 settings = Settings()
 
 
-def setup_environment() -> None:
+def setup_environment() -> Settings:
     """Initialize environment variables and configure logging/tracing.
 
     Exits the program if required variables are missing.
@@ -33,5 +33,6 @@ def setup_environment() -> None:
     logfire.configure()
     logfire.instrument_openai_agents()
 
-    global settings
-    settings = Settings()
+    new_settings = Settings()
+    settings.__dict__.update(vars(new_settings))
+    return settings

--- a/circuitron/settings.py
+++ b/circuitron/settings.py
@@ -7,7 +7,7 @@ Example:
     print(settings.planning_model)
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 
 
@@ -15,15 +15,35 @@ import os
 class Settings:
     """Configuration settings loaded from environment variables."""
 
-    planning_model: str = os.getenv("PLANNING_MODEL", "o4-mini")
-    plan_edit_model: str = os.getenv("PLAN_EDIT_MODEL", "o4-mini")
-    part_finder_model: str = os.getenv("PART_FINDER_MODEL", "o4-mini")
-    part_selection_model: str = os.getenv("PART_SELECTION_MODEL", "o4-mini")
-    documentation_model: str = os.getenv("DOCUMENTATION_MODEL", "o4-mini")
-    code_generation_model: str = os.getenv("CODE_GENERATION_MODEL", "o4-mini")
-    code_validation_model: str = os.getenv("CODE_VALIDATION_MODEL", "o4-mini")
-    calculation_image: str = os.getenv("CALC_IMAGE", "python:3.12-slim")
-    kicad_image: str = os.getenv(
-        "KICAD_IMAGE", "ghcr.io/shaurya-sethi/circuitron-kicad:latest"
+    planning_model: str = field(
+        default_factory=lambda: os.getenv("PLANNING_MODEL", "o4-mini")
     )
-    mcp_url: str = os.getenv("MCP_URL", "http://localhost:8051")
+    plan_edit_model: str = field(
+        default_factory=lambda: os.getenv("PLAN_EDIT_MODEL", "o4-mini")
+    )
+    part_finder_model: str = field(
+        default_factory=lambda: os.getenv("PART_FINDER_MODEL", "o4-mini")
+    )
+    part_selection_model: str = field(
+        default_factory=lambda: os.getenv("PART_SELECTION_MODEL", "o4-mini")
+    )
+    documentation_model: str = field(
+        default_factory=lambda: os.getenv("DOCUMENTATION_MODEL", "o4-mini")
+    )
+    code_generation_model: str = field(
+        default_factory=lambda: os.getenv("CODE_GENERATION_MODEL", "o4-mini")
+    )
+    code_validation_model: str = field(
+        default_factory=lambda: os.getenv("CODE_VALIDATION_MODEL", "o4-mini")
+    )
+    calculation_image: str = field(
+        default_factory=lambda: os.getenv("CALC_IMAGE", "python:3.12-slim")
+    )
+    kicad_image: str = field(
+        default_factory=lambda: os.getenv(
+            "KICAD_IMAGE", "ghcr.io/shaurya-sethi/circuitron-kicad:latest"
+        )
+    )
+    mcp_url: str = field(
+        default_factory=lambda: os.getenv("MCP_URL", "http://localhost:8051")
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,3 +21,24 @@ def test_setup_environment_requires_vars(monkeypatch: pytest.MonkeyPatch) -> Non
     ]:
         assert var in message
 
+
+def test_settings_updated_in_place(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("PLANNING_MODEL", "p1")
+    monkeypatch.setenv("PLAN_EDIT_MODEL", "e1")
+    monkeypatch.setenv("PART_FINDER_MODEL", "f1")
+    monkeypatch.setenv("MCP_URL", "http://a")
+
+    cfg.setup_environment()
+    first_id = id(cfg.settings)
+    import importlib
+    tools = importlib.import_module("circuitron.tools")
+    assert tools.settings is cfg.settings
+
+    monkeypatch.setenv("PLANNING_MODEL", "p2")
+    cfg.setup_environment()
+
+    assert id(cfg.settings) == first_id
+    assert cfg.settings.planning_model == "p2"
+    assert tools.settings is cfg.settings
+


### PR DESCRIPTION
## Summary
- refresh global settings in-place after setup_environment
- read environment variables lazily via `field(default_factory=...)`
- validate that modules share updated settings

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e6f372388333b853e9d2645d339b