### PR TITLE
Add retry wrapper for pipeline

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -7,12 +7,21 @@ from .models import CodeGenerationOutput
 
 
 async def run_circuitron(
-    prompt: str, show_reasoning: bool = False, debug: bool = False
-) -> CodeGenerationOutput:
-    """Execute the Circuitron workflow using the full pipeline."""
-    from circuitron.pipeline import pipeline
+    prompt: str,
+    show_reasoning: bool = False,
+    debug: bool = False,
+    retries: int = 0,
+) -> CodeGenerationOutput | None:
+    """Execute the Circuitron workflow using the full pipeline with retries."""
 
-    return await pipeline(prompt, show_reasoning=show_reasoning, debug=debug)
+    from circuitron.pipeline import run_with_retry
+
+    return await run_with_retry(
+        prompt,
+        show_reasoning=show_reasoning,
+        debug=debug,
+        retries=retries,
+    )
 
 
 def main() -> None:
@@ -25,15 +34,18 @@ def main() -> None:
     prompt = args.prompt or input("Prompt: ")
     show_reasoning = args.reasoning
     debug = args.debug
+    retries = args.retries
 
     code_output: CodeGenerationOutput | None = None
     try:
         try:
             code_output = asyncio.run(
-                run_circuitron(prompt, show_reasoning, debug)
+                run_circuitron(prompt, show_reasoning, debug, retries)
             )
         except KeyboardInterrupt:
             print("\nExecution interrupted by user.")
+        except Exception as exc:
+            print(f"Error during execution: {exc}")
     finally:
         kicad_session.stop()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,23 +9,24 @@ import pytest
 
 def test_run_circuitron_invokes_pipeline() -> None:
     out = CodeGenerationOutput(complete_skidl_code="code")
-    async def fake_pipeline(prompt: str, show_reasoning: bool = False, debug: bool = False) -> CodeGenerationOutput:
+    async def fake_pipeline(prompt: str, show_reasoning: bool = False, debug: bool = False, retries: int = 0) -> CodeGenerationOutput:
         assert prompt == "p"
         assert show_reasoning is True
         assert debug is False
+        assert retries == 1
         return out
 
-    with patch("circuitron.pipeline.pipeline", AsyncMock(side_effect=fake_pipeline)):
-        result: CodeGenerationOutput = asyncio.run(cli.run_circuitron("p", show_reasoning=True))
+    with patch("circuitron.pipeline.run_with_retry", AsyncMock(side_effect=fake_pipeline)):
+        result = asyncio.run(cli.run_circuitron("p", show_reasoning=True, retries=1))
     assert result is out
 
 
 def test_cli_main_uses_args_and_prints(capsys: pytest.CaptureFixture[str]) -> None:
     out = CodeGenerationOutput(complete_skidl_code="abc")
-    args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
-        patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)):
+         patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)):
         cli.main()
     captured = capsys.readouterr().out
     assert "GENERATED SKiDL CODE" in captured
@@ -34,13 +35,13 @@ def test_cli_main_uses_args_and_prints(capsys: pytest.CaptureFixture[str]) -> No
 
 def test_cli_main_prompts_for_input(monkeypatch: pytest.MonkeyPatch) -> None:
     out = CodeGenerationOutput(complete_skidl_code="xyz")
-    args = SimpleNamespace(prompt=None, reasoning=True, debug=True)
+    args = SimpleNamespace(prompt=None, reasoning=True, debug=True, retries=0)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)) as run_mock:
         monkeypatch.setattr("builtins.input", lambda _: "hello")
         cli.main()
-        run_mock.assert_awaited_with("hello", True, True)
+        run_mock.assert_awaited_with("hello", True, True, 0)
 
 
 def test_module_main_called() -> None:
@@ -52,7 +53,7 @@ def test_module_main_called() -> None:
 
 def test_cli_main_stops_session() -> None:
     out = CodeGenerationOutput(complete_skidl_code="123")
-    args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)), \
@@ -63,11 +64,22 @@ def test_cli_main_stops_session() -> None:
 def test_cli_main_handles_keyboardinterrupt(capsys: pytest.CaptureFixture[str]) -> None:
     import circuitron.config as cfg
     cfg.setup_environment()
-    args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
-         patch("circuitron.cli.run_circuitron", AsyncMock(side_effect=KeyboardInterrupt)), \
+        patch("circuitron.cli.run_circuitron", AsyncMock(side_effect=KeyboardInterrupt)), \
          patch("circuitron.tools.kicad_session.stop"):
         cli.main()
     captured = capsys.readouterr().out
     assert "interrupted" in captured.lower()
+
+
+def test_cli_main_handles_exception(capsys: pytest.CaptureFixture[str]) -> None:
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=1)
+    with patch("circuitron.cli.setup_environment"), \
+         patch("circuitron.pipeline.parse_args", return_value=args), \
+         patch("circuitron.cli.run_circuitron", AsyncMock(side_effect=RuntimeError("fail"))), \
+         patch("circuitron.tools.kicad_session.stop"):
+        cli.main()
+    captured = capsys.readouterr().out
+    assert "error" in captured.lower()

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -60,8 +60,13 @@ def test_wrapper_functions() -> None:
 
 
 def test_pipeline_main(monkeypatch: pytest.MonkeyPatch) -> None:
-    args = SimpleNamespace(prompt="p", reasoning=False, debug=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=1)
     monkeypatch.setattr(pl, "parse_args", lambda argv=None: args)
-    monkeypatch.setattr(pl, "pipeline", AsyncMock())
+    monkeypatch.setattr(pl, "run_with_retry", AsyncMock())
     asyncio.run(pl.main())
-    cast(AsyncMock, pl.pipeline).assert_awaited_with("p", show_reasoning=False, debug=False)
+    cast(AsyncMock, pl.run_with_retry).assert_awaited_with(
+        "p",
+        show_reasoning=False,
+        debug=False,
+        retries=1,
+    )


### PR DESCRIPTION
## Summary
- add `run_with_retry` helper to wrap pipeline execution
- expose retry option via CLI and `parse_args`
- handle generic errors in CLI
- test retry logic and update existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e6fa8b9c833388be38b41af3fb1c