### PR TITLE
Expose async run_erc function

### DIFF
--- a/circuitron/agents.py
+++ b/circuitron/agents.py
@@ -37,7 +37,7 @@ from .tools import (
     extract_pin_details,
     create_mcp_documentation_tools,
     create_mcp_validation_tools,
-    run_erc,
+    run_erc_tool,
 )
 
 
@@ -167,7 +167,7 @@ def create_code_correction_agent() -> Agent:
     tools: list[Tool] = [
         *create_mcp_documentation_tools(),
         *create_mcp_validation_tools(),
-        run_erc,
+        run_erc_tool,
     ]
 
     return Agent(

--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -124,7 +124,7 @@ async def run_code_validation(
         pretty_print_validation(validation)
         erc_result: dict[str, object] | None = None
         if validation.status == "pass":
-            erc_json = await run_erc(script_path)  # type: ignore[operator]
+            erc_json = await run_erc(script_path)
             try:
                 erc_result = json.loads(erc_json)
             except Exception:

--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -206,9 +206,19 @@ def create_mcp_validation_tools() -> list[Tool]:
     return [create_mcp_tool("skidl_validation", cache_tools_list=True)]
 
 
-@function_tool
 async def run_erc(script_path: str) -> str:
-    """Run a SKiDL script and perform ERC inside Docker."""
+    """Run a SKiDL script and perform ERC inside Docker.
+
+    Args:
+        script_path: Path to the SKiDL script.
+
+    Returns:
+        JSON string with ``success`` flag, ``erc_passed`` status, stdout, and stderr.
+
+    Example:
+        >>> await run_erc("/tmp/test.py")
+        '{"success": true, "erc_passed": true, "stdout": "", "stderr": ""}'
+    """
 
     wrapper = textwrap.dedent(
         """
@@ -242,3 +252,6 @@ async def run_erc(script_path: str) -> str:
         return json.dumps({'success': False, 'erc_passed': False, 'stdout': '', 'stderr': str(exc)})
 
     return proc.stdout.strip()
+
+
+run_erc_tool = function_tool(run_erc)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -113,20 +113,20 @@ def test_create_mcp_validation_tools() -> None:
 
 def test_run_erc_success() -> None:
     cfg.setup_environment()
-    from circuitron.tools import run_erc
+    from circuitron.tools import run_erc_tool
 
     completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
     with patch("circuitron.tools.kicad_session.exec_erc", return_value=completed) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t7")
         args = json.dumps({"script_path": "/tmp/a.py"})
-        result: str = asyncio.run(cast(Coroutine[Any, Any, str], run_erc.on_invoke_tool(ctx, args)))
+        result: str = asyncio.run(cast(Coroutine[Any, Any, str], run_erc_tool.on_invoke_tool(ctx, args)))
         assert "{}" in result
         run_mock.assert_called_once()
 
 
 def test_run_erc_timeout() -> None:
     cfg.setup_environment()
-    from circuitron.tools import run_erc
+    from circuitron.tools import run_erc_tool
 
     with patch(
         "circuitron.tools.kicad_session.exec_erc",
@@ -134,7 +134,7 @@ def test_run_erc_timeout() -> None:
     ):
         ctx = ToolContext(context=None, tool_call_id="t8")
         args = json.dumps({"script_path": "/tmp/a.py"})
-        result: str = asyncio.run(cast(Coroutine[Any, Any, str], run_erc.on_invoke_tool(ctx, args)))
+        result: str = asyncio.run(cast(Coroutine[Any, Any, str], run_erc_tool.on_invoke_tool(ctx, args)))
         assert "success" in result
 
 


### PR DESCRIPTION
## Summary
- expose `run_erc` async function
- call `run_erc` directly in pipeline
- use `run_erc_tool` when registering tools
- update tests for new name
- add run_erc docstring

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866ec7cec2c8333b6b7a2c5af1d718e