### PR TITLE
Ensure ERC cleanup

### DIFF
--- a/tests/test_docker_session.py
+++ b/tests/test_docker_session.py
@@ -9,7 +9,9 @@ from circuitron.docker_session import DockerSession
 
 def test_reuse_running_container() -> None:
     session = DockerSession("img", "cont")
-    proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="Up 3s\n", stderr="")
+    proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="Up 3s\n", stderr=""
+    )
     with patch.object(session, "_run", return_value=proc) as run_mock:
         session.start()
         assert session.started is True
@@ -19,22 +21,32 @@ def test_reuse_running_container() -> None:
 
 def test_remove_exited_container() -> None:
     session = DockerSession("img", "cont")
-    ps_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="Exited (0) 1s\n", stderr="")
+    ps_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="Exited (0) 1s\n", stderr=""
+    )
     rm_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
     run_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-    with patch.object(session, "_run", side_effect=[ps_proc, rm_proc, run_proc]) as run_mock:
+    with patch.object(
+        session, "_run", side_effect=[ps_proc, rm_proc, run_proc]
+    ) as run_mock:
         session.start()
         assert session.started is True
         assert run_mock.call_args_list[0].args[0][:3] == ["docker", "ps", "-a"]
         assert run_mock.call_args_list[1].args[0][:3] == ["docker", "rm", "-f"]
-        assert run_mock.call_args_list[2].args[0][0] == "docker" and run_mock.call_args_list[2].args[0][1] == "run"
+        assert (
+            run_mock.call_args_list[2].args[0][0] == "docker"
+            and run_mock.call_args_list[2].args[0][1] == "run"
+        )
 
 
 def test_start_logs_failure() -> None:
     session = DockerSession("img", "cont")
     ps_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
     err = subprocess.CalledProcessError(returncode=1, cmd=["docker"], stderr="boom")
-    with patch.object(session, "_run", side_effect=[ps_proc, err]) as run_mock, patch("circuitron.docker_session.logging.error") as log_mock:
+    with (
+        patch.object(session, "_run", side_effect=[ps_proc, err]) as run_mock,
+        patch("circuitron.docker_session.logging.error") as log_mock,
+    ):
         with pytest.raises(RuntimeError):
             session.start()
         log_mock.assert_called_once()
@@ -45,7 +57,10 @@ def test_start_error_message() -> None:
     session = DockerSession("img", "cont")
     ps_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
     err = subprocess.CalledProcessError(returncode=1, cmd=["docker"], stderr="boom")
-    with patch.object(session, "_run", side_effect=[ps_proc, err]), patch("circuitron.docker_session.logging.error"):
+    with (
+        patch.object(session, "_run", side_effect=[ps_proc, err]),
+        patch("circuitron.docker_session.logging.error"),
+    ):
         with pytest.raises(RuntimeError) as info:
             session.start()
         assert "Docker" in str(info.value)
@@ -64,3 +79,21 @@ def test_concurrent_start() -> None:
         t2.join()
         assert session.started is True
         assert run_mock.call_count == 2
+
+
+def test_exec_erc_removes_temp_file_on_error() -> None:
+    session = DockerSession("img", "cont")
+    session.started = True
+    cp_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    err = subprocess.CalledProcessError(returncode=1, cmd=["docker"], stderr="bad")
+    rm_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with patch.object(session, "_run", side_effect=[cp_proc, err, rm_proc]) as run_mock:
+        with pytest.raises(subprocess.CalledProcessError):
+            session.exec_erc("/tmp/x.py", "wrap")
+        assert run_mock.call_args_list[2].args[0][:4] == [
+            "docker",
+            "exec",
+            "-i",
+            session.container_name,
+        ]
+        assert run_mock.call_args_list[2].args[0][-2:] == ["-f", "/tmp/script.py"]


### PR DESCRIPTION
## Summary
- remove temporary script in Docker container when running ERC
- test cleanup on errors

## Testing
- `ruff check circuitron/docker_session.py tests/test_docker_session.py`
- `ruff format circuitron/docker_session.py tests/test_docker_session.py`
- `mypy circuitron/docker_session.py tests/test_docker_session.py`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ecd88db0833399b3c6c50ee6bc7b