### PR TITLE
Add optional logfire tracing with --dev flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # OpenAI Api Key and Logfire Token
 OPENAI_API_KEY=sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# Optional: required only when running with --dev
 LOGFIRE_TOKEN=your_logfire_token_here
 
 # OpenAI models

--- a/README.md
+++ b/README.md
@@ -47,13 +47,20 @@ the CLI and tests can run:
 pip install -e .  # or `pip install .`
 ```
 
-This installs `openai-agents`, `python-dotenv`, `skidl`, and `logfire`.
+This installs `openai-agents`, `python-dotenv`, and `skidl`.
+To enable tracing with `logfire`, install the optional dev extras:
+
+```bash
+pip install -e .[dev]
+```
+
 A matching `requirements.txt` is included for convenience.
 
 Copy `.env.example` to `.env` and fill in the required values:
 
 ```
 OPENAI_API_KEY=<your OpenAI API key>
+# Only required when using --dev for tracing
 LOGFIRE_TOKEN=<your token here>
 PLANNING_MODEL=o4-mini
 PLAN_EDIT_MODEL=o4-mini
@@ -80,7 +87,7 @@ python knowledge_graphs/ai_hallucination_detector.py add https://github.com/pyda
 - [OpenAI Agents SDK](https://github.com/openai/openai-agents) (integration in progress)
 - [SKiDL](https://github.com/xesscorp/skidl) for schematic generation
 - [python-dotenv](https://github.com/theskumar/python-dotenv) for configuration
-- [logfire](https://pydantic.dev/logfire) for observability and tracing
+- [logfire](https://pydantic.dev/logfire) for observability and tracing (optional)
 
 ## Contributing
 
@@ -103,6 +110,11 @@ python -m circuitron "Design a voltage divider"
 After installation:
 ```bash
 circuitron "Design a voltage divider"
+```
+
+Enable tracing during development:
+```bash
+circuitron --dev "Design a voltage divider"
 ```
 
 ### Try the Interactive Notebook:

--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -26,11 +26,12 @@ async def run_circuitron(
 
 def main() -> None:
     """Main entry point for the Circuitron system."""
-    setup_environment()
     from circuitron.pipeline import parse_args
     from circuitron.tools import kicad_session
 
     args = parse_args()
+    setup_environment(dev=args.dev)
+
     prompt = args.prompt or input("Prompt: ")
     show_reasoning = args.reasoning
     debug = args.debug

--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -282,6 +282,9 @@ async def pipeline(
 async def main() -> None:
     """CLI entry point for the Circuitron pipeline."""
     args = parse_args()
+    from circuitron.config import setup_environment
+
+    setup_environment(dev=args.dev)
     prompt = args.prompt or input("Prompt: ")
     await run_with_retry(
         prompt,
@@ -295,12 +298,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments.
 
     Example:
-        >>> args = parse_args(["prompt text", "-r"])
+        >>> args = parse_args(["prompt text", "-r", "--dev"])
     """
     parser = argparse.ArgumentParser(description="Run the Circuitron pipeline")
     parser.add_argument("prompt", nargs="?", help="Design prompt")
     parser.add_argument("-r", "--reasoning", action="store_true", help="show reasoning summary")
     parser.add_argument("-d", "--debug", action="store_true", help="show debug info")
+    parser.add_argument("--dev", action="store_true", help="enable tracing with logfire")
     parser.add_argument(
         "-n",
         "--retries",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ dependencies = [
     "openai-agents==0.1.0",
     "python-dotenv>=1.1.0",
     "skidl>=2.0.1",
+]
+
+[project.optional-dependencies]
+dev = [
     "logfire>=3.22.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 openai-agents==0.1.0
 python-dotenv>=1.1.0
 skidl>=2.0.1
-logfire>=3.22.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ def test_run_circuitron_invokes_pipeline() -> None:
 
 def test_cli_main_uses_args_and_prints(capsys: pytest.CaptureFixture[str]) -> None:
     out = CodeGenerationOutput(complete_skidl_code="abc")
-    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0)
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0, dev=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)):
@@ -35,7 +35,7 @@ def test_cli_main_uses_args_and_prints(capsys: pytest.CaptureFixture[str]) -> No
 
 def test_cli_main_prompts_for_input(monkeypatch: pytest.MonkeyPatch) -> None:
     out = CodeGenerationOutput(complete_skidl_code="xyz")
-    args = SimpleNamespace(prompt=None, reasoning=True, debug=True, retries=0)
+    args = SimpleNamespace(prompt=None, reasoning=True, debug=True, retries=0, dev=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)) as run_mock:
@@ -53,7 +53,7 @@ def test_module_main_called() -> None:
 
 def test_cli_main_stops_session() -> None:
     out = CodeGenerationOutput(complete_skidl_code="123")
-    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0)
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0, dev=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)), \
@@ -64,7 +64,7 @@ def test_cli_main_stops_session() -> None:
 def test_cli_main_handles_keyboardinterrupt(capsys: pytest.CaptureFixture[str]) -> None:
     import circuitron.config as cfg
     cfg.setup_environment()
-    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0)
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0, dev=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
         patch("circuitron.cli.run_circuitron", AsyncMock(side_effect=KeyboardInterrupt)), \
@@ -75,7 +75,7 @@ def test_cli_main_handles_keyboardinterrupt(capsys: pytest.CaptureFixture[str]) 
 
 
 def test_cli_main_handles_exception(capsys: pytest.CaptureFixture[str]) -> None:
-    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=1)
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=1, dev=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.cli.run_circuitron", AsyncMock(side_effect=RuntimeError("fail"))), \

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -74,10 +74,11 @@ def test_pipeline_asyncio() -> None:
 
 def test_parse_args() -> None:
     from circuitron import pipeline as pl
-    args = pl.parse_args(["prompt", "-r", "-d", "-n", "2"])
+    args = pl.parse_args(["prompt", "-r", "-d", "--dev", "-n", "2"])
     assert args.prompt == "prompt"
     assert args.reasoning is True
     assert args.debug is True
+    assert args.dev is True
     assert args.retries == 2
 
 

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -60,7 +60,7 @@ def test_wrapper_functions() -> None:
 
 
 def test_pipeline_main(monkeypatch: pytest.MonkeyPatch) -> None:
-    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=1)
+    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=1, dev=False)
     monkeypatch.setattr(pl, "parse_args", lambda argv=None: args)
     monkeypatch.setattr(pl, "run_with_retry", AsyncMock())
     asyncio.run(pl.main())


### PR DESCRIPTION
## Summary
- make logfire optional via extras in `pyproject.toml`
- gate tracing behind new `--dev` CLI flag
- document optional tracing in README and `.env.example`
- update CLI and pipeline to pass dev flag to environment setup
- adjust tests for new argument

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f3c612348333bb50f40a5c8f1e8f