### PR TITLE
Hardcode agent models and simplify env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,6 @@ OPENAI_API_KEY=sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # Optional: required only when running with --dev
 LOGFIRE_TOKEN=your_logfire_token_here
 
-# OpenAI models
-PLANNING_MODEL=o4-mini
-PLAN_EDIT_MODEL=o4-mini
-PART_FINDER_MODEL=o4-mini
-
 # MCP
 MCP_URL=http://localhost:8051
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,12 @@ Copy `.env.example` to `.env` and fill in the required values:
 OPENAI_API_KEY=<your OpenAI API key>
 # Only required when using --dev for tracing
 LOGFIRE_TOKEN=<your token here>
-PLANNING_MODEL=o4-mini
-PLAN_EDIT_MODEL=o4-mini
-PART_FINDER_MODEL=o4-mini
 MCP_URL=http://localhost:8051
 
 ```
 
 Required variables:
-`OPENAI_API_KEY`, `PLANNING_MODEL`, `PLAN_EDIT_MODEL`, `PART_FINDER_MODEL`, and `MCP_URL`.
+`OPENAI_API_KEY` and `MCP_URL`.
 Optional overrides:
 `CALC_IMAGE` and `KICAD_IMAGE` for custom Docker images.
 

--- a/circuitron/config.py
+++ b/circuitron/config.py
@@ -24,9 +24,6 @@ def setup_environment(dev: bool = False) -> Settings:
 
     required = [
         "OPENAI_API_KEY",
-        "PLANNING_MODEL",
-        "PLAN_EDIT_MODEL",
-        "PART_FINDER_MODEL",
         "MCP_URL",
     ]
     missing = [var for var in required if not os.getenv(var)]

--- a/circuitron/settings.py
+++ b/circuitron/settings.py
@@ -15,27 +15,13 @@ import os
 class Settings:
     """Configuration settings loaded from environment variables."""
 
-    planning_model: str = field(
-        default_factory=lambda: os.getenv("PLANNING_MODEL", "o4-mini")
-    )
-    plan_edit_model: str = field(
-        default_factory=lambda: os.getenv("PLAN_EDIT_MODEL", "o4-mini")
-    )
-    part_finder_model: str = field(
-        default_factory=lambda: os.getenv("PART_FINDER_MODEL", "o4-mini")
-    )
-    part_selection_model: str = field(
-        default_factory=lambda: os.getenv("PART_SELECTION_MODEL", "o4-mini")
-    )
-    documentation_model: str = field(
-        default_factory=lambda: os.getenv("DOCUMENTATION_MODEL", "o4-mini")
-    )
-    code_generation_model: str = field(
-        default_factory=lambda: os.getenv("CODE_GENERATION_MODEL", "o4-mini")
-    )
-    code_validation_model: str = field(
-        default_factory=lambda: os.getenv("CODE_VALIDATION_MODEL", "o4-mini")
-    )
+    planning_model: str = field(default="o4-mini")
+    plan_edit_model: str = field(default="o4-mini")
+    part_finder_model: str = field(default="o4-mini")
+    part_selection_model: str = field(default="o4-mini")
+    documentation_model: str = field(default="o4-mini")
+    code_generation_model: str = field(default="o4-mini")
+    code_validation_model: str = field(default="o4-mini")
     calculation_image: str = field(
         default_factory=lambda: os.getenv("CALC_IMAGE", "python:3.12-slim")
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,17 +4,11 @@ from typing import Iterator
 import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
-os.environ.setdefault("PLANNING_MODEL", "test-model")
-os.environ.setdefault("PLAN_EDIT_MODEL", "test-model")
-os.environ.setdefault("PART_FINDER_MODEL", "test-model")
 os.environ.setdefault("MCP_URL", "http://localhost:8051")
 
 @pytest.fixture(autouse=True)
 def _set_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    monkeypatch.setenv("PLANNING_MODEL", "test-model")
-    monkeypatch.setenv("PLAN_EDIT_MODEL", "test-model")
-    monkeypatch.setenv("PART_FINDER_MODEL", "test-model")
     monkeypatch.setenv("MCP_URL", "http://localhost:8051")
     yield
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,28 +5,16 @@ import circuitron.config as cfg
 
 def test_setup_environment_requires_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("PLANNING_MODEL", raising=False)
-    monkeypatch.delenv("PLAN_EDIT_MODEL", raising=False)
-    monkeypatch.delenv("PART_FINDER_MODEL", raising=False)
     monkeypatch.delenv("MCP_URL", raising=False)
     with pytest.raises(SystemExit) as exc:
         cfg.setup_environment()
     message = str(exc.value)
-    for var in [
-        "OPENAI_API_KEY",
-        "PLANNING_MODEL",
-        "PLAN_EDIT_MODEL",
-        "PART_FINDER_MODEL",
-        "MCP_URL",
-    ]:
+    for var in ["OPENAI_API_KEY", "MCP_URL"]:
         assert var in message
 
 
 def test_settings_updated_in_place(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "k")
-    monkeypatch.setenv("PLANNING_MODEL", "p1")
-    monkeypatch.setenv("PLAN_EDIT_MODEL", "e1")
-    monkeypatch.setenv("PART_FINDER_MODEL", "f1")
     monkeypatch.setenv("MCP_URL", "http://a")
 
     cfg.setup_environment()
@@ -35,10 +23,10 @@ def test_settings_updated_in_place(monkeypatch: pytest.MonkeyPatch) -> None:
     tools = importlib.import_module("circuitron.tools")
     assert tools.settings is cfg.settings
 
-    monkeypatch.setenv("PLANNING_MODEL", "p2")
+    monkeypatch.setenv("MCP_URL", "http://b")
     cfg.setup_environment()
 
     assert id(cfg.settings) == first_id
-    assert cfg.settings.planning_model == "p2"
+    assert cfg.settings.mcp_url == "http://b"
     assert tools.settings is cfg.settings
 


### PR DESCRIPTION
## Summary
- remove environment variables for selecting models
- default all agents to use `o4-mini`
- update configuration and tests for new env requirements
- document new environment setup

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866f65c74588333b8def502b3e3fea4