### PR TITLE
Update MCP tool creation

### DIFF
--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -174,12 +174,11 @@ print(json.dumps(pins))
     return proc.stdout.strip()
 
 
-def create_mcp_tool(server_label: str, *, cache_tools_list: bool = False) -> HostedMCPTool:
+def create_mcp_tool(server_label: str) -> HostedMCPTool:
     """Return a HostedMCPTool configured for the given server label.
 
     Args:
         server_label: The target label of the MCP server.
-        cache_tools_list: Whether to cache the tool list on the server.
 
     Returns:
         HostedMCPTool configured with the appropriate server URL.
@@ -191,19 +190,17 @@ def create_mcp_tool(server_label: str, *, cache_tools_list: bool = False) -> Hos
         "server_url": server_url,
         "require_approval": "never",
     }
-    if cache_tools_list:
-        tool_data["cache_tools_list"] = True
     return HostedMCPTool(tool_config=cast(Mcp, tool_data))
 
 
 def create_mcp_documentation_tools() -> list[Tool]:
     """Create MCP tools for documentation lookup."""
-    return [create_mcp_tool("skidl_docs", cache_tools_list=True)]
+    return [create_mcp_tool("skidl_docs")]
 
 
 def create_mcp_validation_tools() -> list[Tool]:
     """Create MCP tool for hallucination checks."""
-    return [create_mcp_tool("skidl_validation", cache_tools_list=True)]
+    return [create_mcp_tool("skidl_validation")]
 
 
 async def run_erc(script_path: str) -> str:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -96,7 +96,7 @@ def test_create_mcp_documentation_tools() -> None:
     dummy_tool = object()
     with patch("circuitron.tools.create_mcp_tool", return_value=dummy_tool) as helper:
         tools = create_mcp_documentation_tools()
-        helper.assert_called_once_with("skidl_docs", cache_tools_list=True)
+        helper.assert_called_once_with("skidl_docs")
         assert tools == [dummy_tool]
 
 
@@ -107,7 +107,7 @@ def test_create_mcp_validation_tools() -> None:
     dummy_tool = object()
     with patch("circuitron.tools.create_mcp_tool", return_value=dummy_tool) as helper:
         tools = create_mcp_validation_tools()
-        helper.assert_called_once_with("skidl_validation", cache_tools_list=True)
+        helper.assert_called_once_with("skidl_validation")
         assert tools == [dummy_tool]
 
 


### PR DESCRIPTION
## Summary
- stop sending `cache_tools_list` argument when creating MCP tools
- update doc/validation tool helpers accordingly
- align unit tests with new helper usage

## Testing
- `ruff check .`
- `mypy . --strict`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866fcbe0d1c83338356b0f9ab9253e7