### PR TITLE
Verify containers before prompting in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Required variables:
 Optional overrides:
 `CALC_IMAGE` and `KICAD_IMAGE` for custom Docker images.
 
+When you run `circuitron`, the CLI checks that the KiCad container can start.
+If the container fails to launch, an error message is printed and no prompt is
+requested.
+
 To enable hallucination checks, set `USE_KNOWLEDGE_GRAPH=true` and ensure the
 knowledge graph database is populated. The MCP README describes how to add a
 repository, for example:

--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -3,6 +3,7 @@
 import asyncio
 from .config import setup_environment
 from .models import CodeGenerationOutput
+from circuitron.tools import kicad_session
 
 
 
@@ -24,13 +25,26 @@ async def run_circuitron(
     )
 
 
+def verify_containers() -> bool:
+    """Ensure required Docker containers are running."""
+
+    try:
+        kicad_session.start()
+    except Exception as exc:
+        print(f"Failed to start KiCad container: {exc}")
+        return False
+    return True
+
+
 def main() -> None:
     """Main entry point for the Circuitron system."""
     from circuitron.pipeline import parse_args
-    from circuitron.tools import kicad_session
 
     args = parse_args()
     setup_environment(dev=args.dev)
+
+    if not verify_containers():
+        return
 
     prompt = args.prompt or input("Prompt: ")
     show_reasoning = args.reasoning

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,7 @@ def test_cli_main_uses_args_and_prints(capsys: pytest.CaptureFixture[str]) -> No
     args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0, dev=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
+         patch("circuitron.tools.kicad_session.start"), \
          patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)):
         cli.main()
     captured = capsys.readouterr().out
@@ -38,6 +39,7 @@ def test_cli_main_prompts_for_input(monkeypatch: pytest.MonkeyPatch) -> None:
     args = SimpleNamespace(prompt=None, reasoning=True, debug=True, retries=0, dev=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
+         patch("circuitron.tools.kicad_session.start"), \
          patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)) as run_mock:
         monkeypatch.setattr("builtins.input", lambda _: "hello")
         cli.main()
@@ -56,6 +58,7 @@ def test_cli_main_stops_session() -> None:
     args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0, dev=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
+         patch("circuitron.tools.kicad_session.start"), \
          patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)), \
          patch("circuitron.tools.kicad_session.stop") as stop_mock:
         cli.main()
@@ -67,7 +70,8 @@ def test_cli_main_handles_keyboardinterrupt(capsys: pytest.CaptureFixture[str]) 
     args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=0, dev=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
-        patch("circuitron.cli.run_circuitron", AsyncMock(side_effect=KeyboardInterrupt)), \
+         patch("circuitron.tools.kicad_session.start"), \
+         patch("circuitron.cli.run_circuitron", AsyncMock(side_effect=KeyboardInterrupt)), \
          patch("circuitron.tools.kicad_session.stop"):
         cli.main()
     captured = capsys.readouterr().out
@@ -78,8 +82,39 @@ def test_cli_main_handles_exception(capsys: pytest.CaptureFixture[str]) -> None:
     args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=1, dev=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
+         patch("circuitron.tools.kicad_session.start"), \
          patch("circuitron.cli.run_circuitron", AsyncMock(side_effect=RuntimeError("fail"))), \
          patch("circuitron.tools.kicad_session.stop"):
         cli.main()
     captured = capsys.readouterr().out
     assert "error" in captured.lower()
+
+
+def test_verify_containers_success() -> None:
+    with patch("circuitron.tools.kicad_session.start") as start_mock:
+        assert cli.verify_containers() is True
+        start_mock.assert_called_once()
+
+
+def test_verify_containers_failure(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch(
+        "circuitron.tools.kicad_session.start",
+        side_effect=RuntimeError("bad"),
+    ):
+        assert cli.verify_containers() is False
+    captured = capsys.readouterr().out
+    assert "failed to start" in captured.lower()
+
+
+def test_cli_main_no_prompt_on_container_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    args = SimpleNamespace(prompt=None, reasoning=False, debug=False, retries=0, dev=False)
+    out = CodeGenerationOutput(complete_skidl_code="")
+    with patch("circuitron.cli.setup_environment"), \
+         patch("circuitron.pipeline.parse_args", return_value=args), \
+         patch("circuitron.tools.kicad_session.start", side_effect=RuntimeError("bad")), \
+         patch("circuitron.cli.run_circuitron", AsyncMock(return_value=out)) as run_mock, \
+         patch("circuitron.tools.kicad_session.stop"):
+        monkeypatch.setattr("builtins.input", lambda _: (_ for _ in ()).throw(AssertionError("prompt called")))
+        cli.main()
+        run_mock.assert_not_called()
+


### PR DESCRIPTION
## Summary
- ensure CLI checks KiCad container startup before prompting
- show clear message on container startup failure
- test that CLI waits for successful check and add verify_containers tests
- document container check in Quick Start guide

## Testing
- `ruff check circuitron/cli.py tests/test_cli.py`
- `mypy circuitron/cli.py tests/test_cli.py --ignore-missing-imports --no-site-packages --follow-imports=skip`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866fcdd41548333bc0ed6acdedb4bb3