### PR TITLE
feat(dev): debug agent outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Enable tracing during development:
 ```bash
 circuitron --dev "Design a voltage divider"
 ```
+Running with `--dev` also prints each agent's intermediate outputs after every run.
 
 ### Try the Interactive Notebook:
 ```bash

--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -10,7 +10,6 @@ from circuitron.tools import kicad_session
 async def run_circuitron(
     prompt: str,
     show_reasoning: bool = False,
-    debug: bool = False,
     retries: int = 0,
 ) -> CodeGenerationOutput | None:
     """Execute the Circuitron workflow using the full pipeline with retries."""
@@ -20,7 +19,6 @@ async def run_circuitron(
     return await run_with_retry(
         prompt,
         show_reasoning=show_reasoning,
-        debug=debug,
         retries=retries,
     )
 
@@ -48,14 +46,13 @@ def main() -> None:
 
     prompt = args.prompt or input("Prompt: ")
     show_reasoning = args.reasoning
-    debug = args.debug
     retries = args.retries
 
     code_output: CodeGenerationOutput | None = None
     try:
         try:
             code_output = asyncio.run(
-                run_circuitron(prompt, show_reasoning, debug, retries)
+                run_circuitron(prompt, show_reasoning, retries)
             )
         except KeyboardInterrupt:
             print("\nExecution interrupted by user.")

--- a/circuitron/config.py
+++ b/circuitron/config.py
@@ -43,4 +43,5 @@ def setup_environment(dev: bool = False) -> Settings:
 
     new_settings = Settings()
     settings.__dict__.update(vars(new_settings))
+    settings.dev_mode = dev
     return settings

--- a/circuitron/debug.py
+++ b/circuitron/debug.py
@@ -1,0 +1,49 @@
+"""Developer-facing debugging utilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agents import Runner
+from agents.items import MessageOutputItem, ToolCallOutputItem
+from agents.result import RunResult
+
+from .config import settings
+
+
+def display_run_items(result: RunResult) -> None:
+    """Print all new items from an agent run.
+
+    Args:
+        result: The :class:`RunResult` from ``Runner.run``.
+    """
+    for item in result.new_items:
+        agent_name = getattr(item.agent, "name", "agent")
+        if isinstance(item, MessageOutputItem):
+            parts = []
+            for part in item.raw_item.content:
+                text = getattr(part, "text", None)
+                if text:
+                    parts.append(text)
+            text = "".join(parts)
+            print(f"[{agent_name}] MESSAGE: {text}")
+        elif isinstance(item, ToolCallOutputItem):
+            print(f"[{agent_name}] TOOL OUTPUT: {item.output}")
+        else:
+            print(f"[{agent_name}] {item.type}")
+
+
+async def run_agent(agent: Any, input_data: Any) -> RunResult:
+    """Run an agent and display outputs when in dev mode.
+
+    Args:
+        agent: The agent to execute.
+        input_data: The input to pass to the agent.
+
+    Returns:
+        The :class:`RunResult` from the agent run.
+    """
+    result = await Runner.run(agent, input_data)
+    if settings.dev_mode:
+        display_run_items(result)
+    return result

--- a/circuitron/settings.py
+++ b/circuitron/settings.py
@@ -33,3 +33,4 @@ class Settings:
     mcp_url: str = field(
         default_factory=lambda: os.getenv("MCP_URL", "http://localhost:8051")
     )
+    dev_mode: bool = False

--- a/examples/prototype.py
+++ b/examples/prototype.py
@@ -171,18 +171,16 @@ async def run_circuitron(prompt: str) -> RunResult:
 if __name__ == "__main__":
     prompt = sys.argv[1] if len(sys.argv) > 1 else input("Prompt: ")
     show_reasoning = "--reasoning" in sys.argv or "-r" in sys.argv
-    show_debug = "--debug" in sys.argv or "-d" in sys.argv
     
     result = asyncio.run(run_circuitron(prompt))
 
     # Always print the structured plan
     pretty_print_plan(result.final_output)
 
-    # Optionally show calculation codes for debugging
-    if show_debug and result.final_output.calculation_codes:
-        print("\n=== Debug: Calculation Codes ===")
-        for i, code in enumerate(result.final_output.calculation_codes):
-            print(f"\nCalculation #{i+1} code:")
+    if result.final_output.calculation_codes:
+        print("\n=== Calculation Codes ===")
+        for i, code in enumerate(result.final_output.calculation_codes, 1):
+            print(f"\nCalculation #{i} code:")
             print(code)
 
     # Optionally show reasoning summary

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -21,7 +21,7 @@ from circuitron.models import (
 
 async def run_wrappers() -> None:
     with patch("circuitron.pipeline.run_erc", AsyncMock(return_value="{}")), \
-         patch("circuitron.pipeline.Runner.run", AsyncMock()) as run_mock:
+         patch("circuitron.debug.Runner.run", AsyncMock()) as run_mock:
         run_mock.return_value = SimpleNamespace(final_output=PlanOutput())
         await pl.run_planner("p")
         run_mock.assert_awaited_with(pl.planner, "p")  # type: ignore[attr-defined]
@@ -60,13 +60,12 @@ def test_wrapper_functions() -> None:
 
 
 def test_pipeline_main(monkeypatch: pytest.MonkeyPatch) -> None:
-    args = SimpleNamespace(prompt="p", reasoning=False, debug=False, retries=1, dev=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, retries=1, dev=False)
     monkeypatch.setattr(pl, "parse_args", lambda argv=None: args)
     monkeypatch.setattr(pl, "run_with_retry", AsyncMock())
     asyncio.run(pl.main())
     cast(AsyncMock, pl.run_with_retry).assert_awaited_with(
         "p",
         show_reasoning=False,
-        debug=False,
         retries=1,
     )


### PR DESCRIPTION
## Summary
- add `dev_mode` setting and propagate flag from CLI
- print intermediate agent outputs when in dev mode
- wrap agent executions with helper
- remove legacy --debug CLI flag
- update CLI and pipeline tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867066fbe7483338e7eaa305aef93c6