### PR TITLE
Fix MCP integration

### DIFF
--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -5,14 +5,11 @@ Contains calculation tools and other utilities that agents can use.
 """
 
 from agents import function_tool
-from agents.tool import HostedMCPTool, Tool
+from agents.mcp import MCPServerSse
 import asyncio
 import subprocess
 import textwrap
 import json
-import os
-from typing import cast
-from openai.types.responses.tool_param import Mcp
 from .models import CalcResult
 from .config import settings
 from .docker_session import DockerSession
@@ -243,33 +240,30 @@ print(json.dumps(pins))
     return proc.stdout.strip()
 
 
-def create_mcp_tool(server_label: str) -> HostedMCPTool:
-    """Return a HostedMCPTool configured for the given server label.
-
-    Args:
-        server_label: The target label of the MCP server.
+def create_mcp_documentation_server() -> MCPServerSse:
+    """Create MCP server for SKiDL documentation.
 
     Returns:
-        HostedMCPTool configured with the appropriate server URL.
+        MCPServerSse configured for the ``skidl_docs`` server.
     """
-    server_url = os.getenv("MCP_URL", settings.mcp_url)
-    tool_data: dict[str, object] = {
-        "type": "mcp",
-        "server_label": server_label,
-        "server_url": server_url,
-        "require_approval": "never",
-    }
-    return HostedMCPTool(tool_config=cast(Mcp, tool_data))
+    return MCPServerSse(
+        name="skidl_docs",
+        params={"url": "http://localhost:8051/sse"},
+        cache_tools_list=True,
+    )
 
 
-def create_mcp_documentation_tools() -> list[Tool]:
-    """Create MCP tools for documentation lookup."""
-    return [create_mcp_tool("skidl_docs")]
+def create_mcp_validation_server() -> MCPServerSse:
+    """Create MCP server for hallucination validation.
 
-
-def create_mcp_validation_tools() -> list[Tool]:
-    """Create MCP tool for hallucination checks."""
-    return [create_mcp_tool("skidl_validation")]
+    Returns:
+        MCPServerSse configured for the ``skidl_validation`` server.
+    """
+    return MCPServerSse(
+        name="skidl_validation",
+        params={"url": "http://localhost:8051/sse"},
+        cache_tools_list=True,
+    )
 
 
 async def run_erc(script_path: str) -> str:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -4,8 +4,10 @@ import pytest
 
 def test_agent_models_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     import sys
+
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
+
     cfg.setup_environment()
     cfg.settings.planning_model = "x-model"
     cfg.settings.plan_edit_model = "y-model"
@@ -24,8 +26,10 @@ def test_agent_models_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_partfinder_includes_footprint_tool() -> None:
     import sys
+
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
+
     cfg.setup_environment()
     mod = importlib.import_module("circuitron.agents")
     tool_names = [tool.name for tool in mod.part_finder.tools]
@@ -34,36 +38,50 @@ def test_partfinder_includes_footprint_tool() -> None:
 
 def test_partselector_includes_pin_tool() -> None:
     import sys
+
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
+
     cfg.setup_environment()
     mod = importlib.import_module("circuitron.agents")
     tool_names = [tool.name for tool in mod.part_selector.tools]
     assert "extract_pin_details" in tool_names
 
 
-def test_documentation_agent_has_mcp_tool() -> None:
+def test_documentation_agent_has_mcp_server() -> None:
     import sys
+
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
+
     cfg.setup_environment()
     mod = importlib.import_module("circuitron.agents")
-    assert any(tool.__class__.__name__ == "HostedMCPTool" for tool in mod.documentation.tools)
+    assert any(
+        server.__class__.__name__ == "MCPServerSse"
+        for server in mod.documentation.mcp_servers
+    )
 
 
-def test_code_generation_agent_has_mcp_tool() -> None:
+def test_code_generation_agent_has_mcp_server() -> None:
     import sys
+
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
+
     cfg.setup_environment()
     mod = importlib.import_module("circuitron.agents")
-    assert any(tool.__class__.__name__ == "HostedMCPTool" for tool in mod.code_generator.tools)
+    assert any(
+        server.__class__.__name__ == "MCPServerSse"
+        for server in mod.code_generator.mcp_servers
+    )
 
 
 def test_code_corrector_configuration() -> None:
     import sys
+
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
+
     cfg.setup_environment()
     mod = importlib.import_module("circuitron.agents")
     assert mod.code_corrector.model == cfg.settings.code_validation_model
@@ -73,8 +91,10 @@ def test_code_corrector_configuration() -> None:
 
 def test_tool_choice_auto_for_o4mini() -> None:
     import sys
+
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
+
     cfg.setup_environment()
     mod = importlib.import_module("circuitron.agents")
     assert mod.documentation.model_settings.tool_choice == "auto"
@@ -84,8 +104,10 @@ def test_tool_choice_auto_for_o4mini() -> None:
 
 def test_tool_choice_required_for_full_model() -> None:
     import sys
+
     sys.modules.pop("circuitron.agents", None)
     import circuitron.config as cfg
+
     cfg.setup_environment()
     cfg.settings.documentation_model = "gpt-4o"
     cfg.settings.code_validation_model = "gpt-4o"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -11,12 +11,22 @@ import circuitron.config as cfg
 def test_search_kicad_libraries() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_libraries
+
     fake_output = '[{"name": "LM324", "library": "linear", "footprint": "DIP-14", "description": "op amp"}]'
-    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=fake_output, stderr="")
-    with patch("circuitron.tools.kicad_session.exec_python", return_value=completed) as run_mock:
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=fake_output, stderr=""
+    )
+    with patch(
+        "circuitron.tools.kicad_session.exec_python", return_value=completed
+    ) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t1")
         args = json.dumps({"query": "opamp lm324"})
-        result: str = asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_libraries.on_invoke_tool(ctx, args)))
+        result: str = asyncio.run(
+            cast(
+                Coroutine[Any, Any, str],
+                search_kicad_libraries.on_invoke_tool(ctx, args),
+            )
+        )
         data = json.loads(result)
         assert data[0]["name"] == "LM324"
         run_mock.assert_called_once()
@@ -25,25 +35,41 @@ def test_search_kicad_libraries() -> None:
 def test_search_kicad_libraries_timeout() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_libraries
+
     with patch(
         "circuitron.tools.kicad_session.exec_python",
         side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
     ):
         ctx = ToolContext(context=None, tool_call_id="t2")
         args = json.dumps({"query": "123"})
-        result: str = asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_libraries.on_invoke_tool(ctx, args)))
+        result: str = asyncio.run(
+            cast(
+                Coroutine[Any, Any, str],
+                search_kicad_libraries.on_invoke_tool(ctx, args),
+            )
+        )
         assert "error" in result.lower()
 
 
 def test_search_kicad_footprints() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_footprints
+
     fake_output = '[{"name": "SOIC-8", "library": "Package_SO", "description": "soic"}]'
-    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=fake_output, stderr="")
-    with patch("circuitron.tools.kicad_session.exec_python", return_value=completed) as run_mock:
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=fake_output, stderr=""
+    )
+    with patch(
+        "circuitron.tools.kicad_session.exec_python", return_value=completed
+    ) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t3")
         args = json.dumps({"query": "SOIC-8"})
-        result: str = asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_footprints.on_invoke_tool(ctx, args)))
+        result: str = asyncio.run(
+            cast(
+                Coroutine[Any, Any, str],
+                search_kicad_footprints.on_invoke_tool(ctx, args),
+            )
+        )
         data = json.loads(result)
         assert data[0]["name"] == "SOIC-8"
         run_mock.assert_called_once()
@@ -52,25 +78,40 @@ def test_search_kicad_footprints() -> None:
 def test_search_kicad_footprints_timeout() -> None:
     cfg.setup_environment()
     from circuitron.tools import search_kicad_footprints
+
     with patch(
         "circuitron.tools.kicad_session.exec_python",
         side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
     ):
         ctx = ToolContext(context=None, tool_call_id="t4")
         args = json.dumps({"query": "DIP"})
-        result: str = asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_footprints.on_invoke_tool(ctx, args)))
+        result: str = asyncio.run(
+            cast(
+                Coroutine[Any, Any, str],
+                search_kicad_footprints.on_invoke_tool(ctx, args),
+            )
+        )
         assert "error" in result.lower()
 
 
 def test_extract_pin_details() -> None:
     cfg.setup_environment()
     from circuitron.tools import extract_pin_details
+
     fake_output = '[{"number": "1", "name": "VCC", "function": "POWER"}]'
-    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=fake_output, stderr="")
-    with patch("circuitron.tools.kicad_session.exec_python", return_value=completed) as run_mock:
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=fake_output, stderr=""
+    )
+    with patch(
+        "circuitron.tools.kicad_session.exec_python", return_value=completed
+    ) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t5")
         args = json.dumps({"library": "linear", "part_name": "lm386"})
-        result: str = asyncio.run(cast(Coroutine[Any, Any, str], extract_pin_details.on_invoke_tool(ctx, args)))
+        result: str = asyncio.run(
+            cast(
+                Coroutine[Any, Any, str], extract_pin_details.on_invoke_tool(ctx, args)
+            )
+        )
         data = json.loads(result)
         assert data[0]["name"] == "VCC"
         run_mock.assert_called_once()
@@ -79,47 +120,56 @@ def test_extract_pin_details() -> None:
 def test_extract_pin_details_timeout() -> None:
     cfg.setup_environment()
     from circuitron.tools import extract_pin_details
+
     with patch(
         "circuitron.tools.kicad_session.exec_python",
         side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
     ):
         ctx = ToolContext(context=None, tool_call_id="t6")
         args = json.dumps({"library": "lin", "part_name": "bad"})
-        result: str = asyncio.run(cast(Coroutine[Any, Any, str], extract_pin_details.on_invoke_tool(ctx, args)))
+        result: str = asyncio.run(
+            cast(
+                Coroutine[Any, Any, str], extract_pin_details.on_invoke_tool(ctx, args)
+            )
+        )
         assert "error" in result.lower()
 
 
-def test_create_mcp_documentation_tools() -> None:
+def test_create_mcp_documentation_server() -> None:
     cfg.setup_environment()
-    from circuitron.tools import create_mcp_documentation_tools
+    from circuitron.tools import create_mcp_documentation_server, MCPServerSse
 
-    dummy_tool = object()
-    with patch("circuitron.tools.create_mcp_tool", return_value=dummy_tool) as helper:
-        tools = create_mcp_documentation_tools()
-        helper.assert_called_once_with("skidl_docs")
-        assert tools == [dummy_tool]
+    server = create_mcp_documentation_server()
+    assert isinstance(server, MCPServerSse)
+    assert server.name == "skidl_docs"
+    assert server.params["url"] == "http://localhost:8051/sse"
 
 
-def test_create_mcp_validation_tools() -> None:
+def test_create_mcp_validation_server() -> None:
     cfg.setup_environment()
-    from circuitron.tools import create_mcp_validation_tools
+    from circuitron.tools import create_mcp_validation_server, MCPServerSse
 
-    dummy_tool = object()
-    with patch("circuitron.tools.create_mcp_tool", return_value=dummy_tool) as helper:
-        tools = create_mcp_validation_tools()
-        helper.assert_called_once_with("skidl_validation")
-        assert tools == [dummy_tool]
+    server = create_mcp_validation_server()
+    assert isinstance(server, MCPServerSse)
+    assert server.name == "skidl_validation"
+    assert server.params["url"] == "http://localhost:8051/sse"
 
 
 def test_run_erc_success() -> None:
     cfg.setup_environment()
     from circuitron.tools import run_erc_tool
 
-    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
-    with patch("circuitron.tools.kicad_session.exec_erc", return_value=completed) as run_mock:
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="{}", stderr=""
+    )
+    with patch(
+        "circuitron.tools.kicad_session.exec_erc", return_value=completed
+    ) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t7")
         args = json.dumps({"script_path": "/tmp/a.py"})
-        result: str = asyncio.run(cast(Coroutine[Any, Any, str], run_erc_tool.on_invoke_tool(ctx, args)))
+        result: str = asyncio.run(
+            cast(Coroutine[Any, Any, str], run_erc_tool.on_invoke_tool(ctx, args))
+        )
         assert "{}" in result
         run_mock.assert_called_once()
 
@@ -134,7 +184,9 @@ def test_run_erc_timeout() -> None:
     ):
         ctx = ToolContext(context=None, tool_call_id="t8")
         args = json.dumps({"script_path": "/tmp/a.py"})
-        result: str = asyncio.run(cast(Coroutine[Any, Any, str], run_erc_tool.on_invoke_tool(ctx, args)))
+        result: str = asyncio.run(
+            cast(Coroutine[Any, Any, str], run_erc_tool.on_invoke_tool(ctx, args))
+        )
         assert "success" in result
 
 
@@ -143,15 +195,31 @@ def test_kicad_session_start_once() -> None:
     from circuitron.tools import search_kicad_libraries, kicad_session
 
     kicad_session.started = False
-    fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr="")
+    fake_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="[]", stderr=""
+    )
+
     def fake_start() -> None:
         kicad_session.started = True
 
-    with patch.object(kicad_session, "_run", return_value=fake_proc) as _run_mock, patch.object(kicad_session, "start", side_effect=fake_start) as start_mock:
+    with (
+        patch.object(kicad_session, "_run", return_value=fake_proc) as _run_mock,
+        patch.object(kicad_session, "start", side_effect=fake_start) as start_mock,
+    ):
         ctx = ToolContext(context=None, tool_call_id="t9")
         args = json.dumps({"query": "foo"})
-        asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_libraries.on_invoke_tool(ctx, args)))
-        asyncio.run(cast(Coroutine[Any, Any, str], search_kicad_libraries.on_invoke_tool(ctx, args)))
+        asyncio.run(
+            cast(
+                Coroutine[Any, Any, str],
+                search_kicad_libraries.on_invoke_tool(ctx, args),
+            )
+        )
+        asyncio.run(
+            cast(
+                Coroutine[Any, Any, str],
+                search_kicad_libraries.on_invoke_tool(ctx, args),
+            )
+        )
         assert start_mock.call_count == 2
         assert _run_mock.call_count == 2
     kicad_session.started = False


### PR DESCRIPTION
## Summary
- switch from `HostedMCPTool` to `MCPServerSse`
- expose helper functions for creating MCP servers
- connect documentation, code generation, validation and correction agents to MCP servers
- update tests for new MCP server API

## Testing
- `ruff check circuitron tests`
- `mypy circuitron tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f09cbf7883338cb8e9a5df4fc586