### PR TITLE
Improve Docker container lifecycle handling

### DIFF
--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -38,7 +38,8 @@ __all__ = [
 ]
 
 
-kicad_session = DockerSession(settings.kicad_image, "circuitron-kicad")
+container_name = f"circuitron-kicad-{os.getpid()}"
+kicad_session = DockerSession(settings.kicad_image, container_name)
 
 
 @function_tool

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -232,3 +232,8 @@ def test_kicad_session_start_once() -> None:
         assert start_mock.call_count == 2
         assert _run_mock.call_count == 2
     kicad_session.started = False
+
+
+def test_kicad_session_container_name_contains_pid() -> None:
+    from circuitron.tools import kicad_session
+    assert str(os.getpid()) in kicad_session.container_name


### PR DESCRIPTION
## Summary
- add stale container cleanup and health check in `DockerSession`
- generate unique KiCad container names per process
- ensure `DockerSession` cleanup is registered via `atexit`
- test Docker session lifecycle and container naming

## Affected Files
- `circuitron/docker_session.py`
- `circuitron/tools.py`
- `tests/test_docker_session.py`
- `tests/test_tools.py`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681e49a3e883339af51a4674a8d580