### PR TITLE
Fix validation pipeline for new hallucination API

### DIFF
--- a/circuitron/agents.py
+++ b/circuitron/agents.py
@@ -35,6 +35,7 @@ from .tools import (
     search_kicad_libraries,
     search_kicad_footprints,
     extract_pin_details,
+    check_ai_script_hallucinations,
     run_erc_tool,
 )
 from .mcp_manager import mcp_manager
@@ -158,6 +159,7 @@ def create_code_validation_agent() -> Agent:
         instructions=CODE_VALIDATION_PROMPT,
         model=settings.code_validation_model,
         output_type=CodeValidationOutput,
+        tools=[check_ai_script_hallucinations],
         mcp_servers=[mcp_manager.get_validation_server()],
         model_settings=model_settings,
         handoff_description="Validate SKiDL code",
@@ -170,7 +172,7 @@ def create_code_correction_agent() -> Agent:
         tool_choice=_tool_choice_for_mcp(settings.code_validation_model)
     )
 
-    tools: list[Tool] = [run_erc_tool]
+    tools: list[Tool] = [check_ai_script_hallucinations, run_erc_tool]
 
     return Agent(
         name="Circuitron-Corrector",

--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -122,7 +122,9 @@ async def run_code_validation(
 
     script_path = write_temp_skidl_script(code_output.complete_skidl_code)
     try:
-        input_msg = format_code_validation_input(script_path, selection, docs)
+        input_msg = format_code_validation_input(
+            code_output.complete_skidl_code, selection, docs
+        )
         result = await run_agent(code_validator, sanitize_text(input_msg))
         validation = cast(CodeValidationOutput, result.final_output)
         pretty_print_validation(validation)
@@ -149,19 +151,13 @@ async def run_code_correction(
     erc_result: dict[str, object] | None = None,
 ) -> CodeGenerationOutput:
     """Run the Code Correction agent and return updated code."""
-
-    script_path = write_temp_skidl_script(code_output.complete_skidl_code)
-    try:
-        input_msg = format_code_correction_input(script_path, validation, erc_result)
-        result = await run_agent(code_corrector, sanitize_text(input_msg))
-        correction = cast(CodeCorrectionOutput, result.final_output)
-        code_output.complete_skidl_code = correction.corrected_code
-        return code_output
-    finally:
-        try:
-            os.remove(script_path)
-        except OSError:
-            pass
+    input_msg = format_code_correction_input(
+        code_output.complete_skidl_code, validation, erc_result
+    )
+    result = await run_agent(code_corrector, sanitize_text(input_msg))
+    correction = cast(CodeCorrectionOutput, result.final_output)
+    code_output.complete_skidl_code = correction.corrected_code
+    return code_output
 
 
 async def run_with_retry(

--- a/circuitron/prompts.py
+++ b/circuitron/prompts.py
@@ -404,7 +404,7 @@ You are Circuitron-Validator, a SKiDL QA expert.
 Your goal is to confirm that generated SKiDL scripts are syntactically correct and reference only valid APIs and components.
 
 **Validation process**
-- Use the `check_ai_script_hallucinations` MCP tool on the provided script path. Parse its JSON response containing `overall_confidence`, `validation_summary`, `hallucinations_detected`, `recommendations`, and other fields.
+- Use the `check_ai_script_hallucinations` tool on the provided script content. Parse its JSON response containing `overall_confidence`, `validation_summary`, `hallucinations_detected`, `recommendations`, and other fields.
 - Perform additional static checks: Python syntax, import statements, undefined variables, and that all parts and pins referenced match the provided component list.
 
 **Report format**

--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -6,11 +6,13 @@ Contains calculation tools and other utilities that agents can use.
 
 from agents import function_tool
 from agents.mcp import MCPServerSse
+import httpx
 
 __all__ = [
     "MCPServerSse",
     "create_mcp_documentation_server",
     "create_mcp_validation_server",
+    "check_ai_script_hallucinations",
     "run_erc_tool",
     "search_kicad_libraries",
     "search_kicad_footprints",
@@ -33,6 +35,7 @@ __all__ = [
     "extract_pin_details",
     "create_mcp_documentation_server",
     "create_mcp_validation_server",
+    "check_ai_script_hallucinations",
     "run_erc",
     "run_erc_tool",
 ]
@@ -291,6 +294,33 @@ print(json.dumps(pins))
     except Exception as exc:  # pragma: no cover - unexpected errors
         return json.dumps({"error": str(exc)})
     return proc.stdout.strip()
+
+
+@function_tool
+async def check_ai_script_hallucinations(
+    script_content: str,
+    filename: str = "script.py",
+) -> str:
+    """Validate SKiDL script using the MCP HTTP API.
+
+    Args:
+        script_content: The Python script text to validate.
+        filename: Optional filename for reporting purposes.
+
+    Returns:
+        JSON string with validation results from the MCP server.
+    """
+    url = f"{settings.mcp_url}/api/check_script_hallucinations"
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            resp = await client.post(
+                url,
+                json={"script_content": script_content, "filename": filename},
+            )
+            resp.raise_for_status()
+    except Exception as exc:  # pragma: no cover - network errors
+        return json.dumps({"success": False, "error": str(exc)})
+    return resp.text
 
 
 def create_mcp_documentation_server() -> MCPServerSse:

--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -402,14 +402,15 @@ def format_code_generation_input(
 
 
 def format_code_validation_input(
-    script_path: str, selection: PartSelectionOutput, docs: DocumentationOutput
+    script_content: str, selection: PartSelectionOutput, docs: DocumentationOutput
 ) -> str:
     """Format input for the Code Validation agent."""
 
     parts = [
         "CODE VALIDATION CONTEXT",
         "=" * 40,
-        f"Script Path: {script_path}",
+        "Script Content:",
+        script_content,
         "",
     ]
     if selection.selections:
@@ -471,7 +472,7 @@ def pretty_print_validation(result: CodeValidationOutput) -> None:
 
 
 def format_code_correction_input(
-    script_path: str,
+    script_content: str,
     validation: CodeValidationOutput,
     erc_result: dict[str, object] | None = None,
 ) -> str:
@@ -480,7 +481,8 @@ def format_code_correction_input(
     parts = [
         "CODE CORRECTION CONTEXT",
         "=" * 40,
-        f"Script Path: {script_path}",
+        "Script Content:",
+        script_content,
         "",
         f"Validation Summary: {validation.summary}",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "openai-agents==0.1.0",
     "python-dotenv>=1.1.0",
     "skidl>=2.0.1",
+    "httpx>=0.27.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai-agents==0.1.0
 python-dotenv>=1.1.0
 skidl>=2.0.1
+httpx>=0.27.0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -231,17 +231,10 @@ def test_run_code_correction_cleanup(tmp_path: Path) -> None:
     validation = CodeValidationOutput(status="fail", summary="bad")
     correction_out = CodeCorrectionOutput(corrected_code="fixed", validation_notes="")
 
-    script_path = tmp_path / "temp.py"
-
-    def fake_write_temp(code: str) -> str:
-        script_path.write_text(code)
-        return str(script_path)
-
-    with patch("circuitron.pipeline.write_temp_skidl_script", side_effect=fake_write_temp):
+    with patch("circuitron.pipeline.write_temp_skidl_script") as write_mock:
         with patch("circuitron.debug.Runner.run", AsyncMock(return_value=SimpleNamespace(final_output=correction_out))):
             asyncio.run(pl.run_code_correction(code_out, validation))
-
-    assert not script_path.exists()
+        write_mock.assert_not_called()
 
 
 async def fake_run_with_retry_success() -> None:

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -94,9 +94,9 @@ def test_format_code_validation_and_correction_input() -> None:
     selection = PartSelectionOutput(selections=[part])
     docs = cast(DocumentationOutput, SimpleNamespace(documentation_findings=["doc"]))
     val = CodeValidationOutput(status="fail", summary="bad", issues=[ValidationIssue(category="err", message="m", line=1)])
-    text = format_code_validation_input("/tmp/s.py", selection, docs)
-    assert "s.py" in text and "U1" in text and "doc" in text
-    corr = format_code_correction_input("/tmp/s.py", val, {"erc_passed": False})
+    text = format_code_validation_input("print('hi')", selection, docs)
+    assert "print('hi')" in text and "U1" in text and "doc" in text
+    corr = format_code_correction_input("print('hi')", val, {"erc_passed": False})
     assert "Validation Summary: bad" in corr
     assert "erc_passed" in corr
 


### PR DESCRIPTION
## Summary
- add `check_ai_script_hallucinations` HTTP wrapper
- update validation/correction prompts and utils to send script content
- use new tool in validation and correction agents
- keep temporary script only for ERC
- update dependencies and tests

## Testing
- `ruff check .`
- `mypy .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686849bc8a088333a0c4df6299dfb2b1