### PR TITLE
Switch to knowledge graph validation

### DIFF
--- a/circuitron/agents.py
+++ b/circuitron/agents.py
@@ -35,7 +35,6 @@ from .tools import (
     search_kicad_libraries,
     search_kicad_footprints,
     extract_pin_details,
-    check_ai_script_hallucinations,
     run_erc_tool,
 )
 from .mcp_manager import mcp_manager
@@ -159,7 +158,7 @@ def create_code_validation_agent() -> Agent:
         instructions=CODE_VALIDATION_PROMPT,
         model=settings.code_validation_model,
         output_type=CodeValidationOutput,
-        tools=[check_ai_script_hallucinations],
+        tools=[],
         mcp_servers=[mcp_manager.get_validation_server()],
         model_settings=model_settings,
         handoff_description="Validate SKiDL code",
@@ -172,7 +171,7 @@ def create_code_correction_agent() -> Agent:
         tool_choice=_tool_choice_for_mcp(settings.code_validation_model)
     )
 
-    tools: list[Tool] = [check_ai_script_hallucinations, run_erc_tool]
+    tools: list[Tool] = [run_erc_tool]
 
     return Agent(
         name="Circuitron-Corrector",

--- a/circuitron/models.py
+++ b/circuitron/models.py
@@ -270,38 +270,27 @@ class ValidationIssue(BaseModel):
     message: str = Field(..., description="Human readable description of the issue")
 
 
-class ValidationSummary(BaseModel):
-    """Summary counts from hallucination checking."""
 
-    total_validations: int
-    valid_count: int
-    invalid_count: int
-    uncertain_count: int
-    not_found_count: int
-    hallucination_rate: float
+class APIValidationResult(BaseModel):
+    """Validation result for a specific API call."""
 
-
-class AnalysisMetadata(BaseModel):
-    """Metadata about script analysis."""
-
-    total_imports: int
-    total_classes: int
-    total_methods: int
-    total_attributes: int
-    total_functions: int
+    api_name: str
+    api_type: Literal["function", "method", "class"]
+    target_class: str | None = None
+    line_number: int | None = None
+    is_valid: bool
+    fix_suggestion: str | None = None
 
 
-class HallucinationReport(BaseModel):
-    """Result from ``check_ai_script_hallucinations``."""
+class KnowledgeGraphValidationReport(BaseModel):
+    """Aggregate results from knowledge graph validation."""
 
-    success: bool
-    script_path: str
-    overall_confidence: float | int
-    validation_summary: ValidationSummary
-    hallucinations_detected: bool
-    recommendations: List[str] = Field(default_factory=list)
-    analysis_metadata: AnalysisMetadata
-    libraries_analyzed: List[str] = Field(default_factory=list)
+    total_apis_checked: int
+    valid_apis: int
+    invalid_apis: int
+    confidence_score: float
+    validation_details: List[APIValidationResult] = Field(default_factory=list)
+    skidl_insights: List[str] = Field(default_factory=list)
 
 
 class CodeValidationOutput(BaseModel):
@@ -312,7 +301,7 @@ class CodeValidationOutput(BaseModel):
     status: Literal["pass", "fail"]
     summary: str = Field(..., description="Overall validation summary")
     issues: List[ValidationIssue] = Field(default_factory=list)
-    hallucination_report: HallucinationReport | None = None
+    kg_validation_report: KnowledgeGraphValidationReport | None = None
 
 
 class CodeCorrectionOutput(BaseModel):

--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -6,13 +6,11 @@ Contains calculation tools and other utilities that agents can use.
 
 from agents import function_tool
 from agents.mcp import MCPServerSse
-import httpx
 
 __all__ = [
     "MCPServerSse",
     "create_mcp_documentation_server",
     "create_mcp_validation_server",
-    "check_ai_script_hallucinations",
     "run_erc_tool",
     "search_kicad_libraries",
     "search_kicad_footprints",
@@ -35,7 +33,6 @@ __all__ = [
     "extract_pin_details",
     "create_mcp_documentation_server",
     "create_mcp_validation_server",
-    "check_ai_script_hallucinations",
     "run_erc",
     "run_erc_tool",
 ]
@@ -295,32 +292,6 @@ print(json.dumps(pins))
         return json.dumps({"error": str(exc)})
     return proc.stdout.strip()
 
-
-@function_tool
-async def check_ai_script_hallucinations(
-    script_content: str,
-    filename: str = "script.py",
-) -> str:
-    """Validate SKiDL script using the MCP HTTP API.
-
-    Args:
-        script_content: The Python script text to validate.
-        filename: Optional filename for reporting purposes.
-
-    Returns:
-        JSON string with validation results from the MCP server.
-    """
-    url = f"{settings.mcp_url}/api/check_script_hallucinations"
-    try:
-        async with httpx.AsyncClient(timeout=20.0) as client:
-            resp = await client.post(
-                url,
-                json={"script_content": script_content, "filename": filename},
-            )
-            resp.raise_for_status()
-    except Exception as exc:  # pragma: no cover - network errors
-        return json.dumps({"success": False, "error": str(exc)})
-    return resp.text
 
 
 def create_mcp_documentation_server() -> MCPServerSse:

--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -17,7 +17,6 @@ from .models import (
     DocumentationOutput,
     CodeGenerationOutput,
     CodeValidationOutput,
-    HallucinationReport,
 )
 
 
@@ -451,12 +450,6 @@ def write_temp_skidl_script(code: str) -> str:
     with os.fdopen(fd, "w") as fh:
         fh.write(code)
     return path
-
-
-def parse_hallucination_report(text: str) -> HallucinationReport:
-    """Parse JSON response from check_ai_script_hallucinations."""
-
-    return HallucinationReport.model_validate_json(text)
 
 
 def pretty_print_validation(result: CodeValidationOutput) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,9 +7,8 @@ from circuitron.models import (
     DocumentationOutput,
     CodeGenerationOutput,
     ValidationIssue,
-    HallucinationReport,
-    ValidationSummary,
-    AnalysisMetadata,
+    APIValidationResult,
+    KnowledgeGraphValidationReport,
     CodeValidationOutput,
 )
 
@@ -46,36 +45,27 @@ def test_code_generation_output() -> None:
 
 def test_code_validation_output() -> None:
     issue = ValidationIssue(line=1, category="syntax", message="bad")
-    summary = ValidationSummary(
-        total_validations=1,
-        valid_count=1,
-        invalid_count=0,
-        uncertain_count=0,
-        not_found_count=0,
-        hallucination_rate=0.0,
+    api_result = APIValidationResult(
+        api_name="generate_netlist",
+        api_type="function",
+        target_class=None,
+        line_number=1,
+        is_valid=True,
+        fix_suggestion=None,
     )
-    meta = AnalysisMetadata(
-        total_imports=1,
-        total_classes=0,
-        total_methods=0,
-        total_attributes=0,
-        total_functions=0,
-    )
-    report = HallucinationReport(
-        success=True,
-        script_path="x.py",
-        overall_confidence=0.9,
-        validation_summary=summary,
-        hallucinations_detected=False,
-        recommendations=[],
-        analysis_metadata=meta,
-        libraries_analyzed=[],
+    report = KnowledgeGraphValidationReport(
+        total_apis_checked=1,
+        valid_apis=1,
+        invalid_apis=0,
+        confidence_score=1.0,
+        validation_details=[api_result],
+        skidl_insights=[],
     )
     out = CodeValidationOutput(
         status="pass",
         summary="ok",
         issues=[issue],
-        hallucination_report=report,
+        kg_validation_report=report,
     )
     assert out.status == "pass"
     assert out.issues[0].category == "syntax"

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -12,22 +12,18 @@ from openai.types.responses.response_reasoning_item import ResponseReasoningItem
 from circuitron.models import (
     CodeGenerationOutput,
     PlanOutput,
-    AnalysisMetadata,
     CodeValidationOutput,
     DocumentationOutput,
-    HallucinationReport,
     PartSelectionOutput,
     PinDetail,
     SelectedPart,
     ValidationIssue,
-    ValidationSummary,
 )
 from circuitron.utils import (
     extract_reasoning_summary,
     format_code_validation_input,
     format_code_correction_input,
     pretty_print_plan,
-    parse_hallucination_report,
     pretty_print_edited_plan,
     pretty_print_found_parts,
     pretty_print_selected_parts,
@@ -55,37 +51,6 @@ def test_write_temp_skidl_script(tmp_path: Path) -> None:
     assert "print('hi')" in content
     os.remove(path)
 
-
-def test_parse_hallucination_report_roundtrip() -> None:
-    summary = ValidationSummary(
-        total_validations=1,
-        valid_count=1,
-        invalid_count=0,
-        uncertain_count=0,
-        not_found_count=0,
-        hallucination_rate=0.0,
-    )
-    meta = AnalysisMetadata(
-        total_imports=0,
-        total_classes=0,
-        total_methods=0,
-        total_attributes=0,
-        total_functions=0,
-    )
-    report = HallucinationReport(
-        success=True,
-        script_path="x.py",
-        overall_confidence=0.9,
-        validation_summary=summary,
-        hallucinations_detected=False,
-        recommendations=[],
-        analysis_metadata=meta,
-        libraries_analyzed=["lib"],
-    )
-    text = report.model_dump_json()
-    parsed = parse_hallucination_report(text)
-    assert parsed.script_path == "x.py"
-    assert parsed.validation_summary.valid_count == 1
 
 
 def test_format_code_validation_and_correction_input() -> None:


### PR DESCRIPTION
## Summary
- remove hallucination checker tool and references
- replace HallucinationReport models with knowledge graph validation models
- update validator and corrector agent prompts for new process
- adjust agents and utils for new validation
- update tests for new model classes

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686925d085bc8333b698c718f16295cd