### PR TITLE
Fix Unicode file writing

### DIFF
--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -447,7 +447,9 @@ def write_temp_skidl_script(code: str) -> str:
     """Write SKiDL code to a temporary script and return its path."""
 
     fd, path = tempfile.mkstemp(prefix="skidl_", suffix=".py")
-    with os.fdopen(fd, "w") as fh:
+    # Explicitly use UTF-8 so that Unicode characters in prompts or generated
+    # code do not cause cross-platform encoding issues.
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
         fh.write(code)
     return path
 

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -52,6 +52,16 @@ def test_write_temp_skidl_script(tmp_path: Path) -> None:
     os.remove(path)
 
 
+def test_write_temp_skidl_script_unicode(tmp_path: Path) -> None:
+    code = "print('\u03a9')"
+    path = write_temp_skidl_script(code)
+    assert os.path.exists(path)
+    with open(path, encoding="utf-8") as fh:
+        content = fh.read()
+    assert "\u03a9" in content
+    os.remove(path)
+
+
 
 def test_format_code_validation_and_correction_input() -> None:
     pin = PinDetail(number="1", name="VCC", function="pwr")


### PR DESCRIPTION
## Summary
- ensure UTF-8 encoding when writing temporary SKiDL scripts
- test writing unicode to SKiDL temp files

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693163bd8c8333b0973abeb09c3ce4