### PR TITLE
Consolidate MCP server management

### DIFF
--- a/circuitron/mcp_manager.py
+++ b/circuitron/mcp_manager.py
@@ -6,52 +6,48 @@ import logging
 
 from agents.mcp import MCPServer
 
-from .tools import create_mcp_documentation_server, create_mcp_validation_server
+from .tools import create_mcp_server
 
 
 class MCPManager:
     """Central manager for MCP server connections."""
 
     def __init__(self) -> None:
-        self._doc_server = create_mcp_documentation_server()
-        self._validation_server = create_mcp_validation_server()
-        self._servers: list[MCPServer] = [self._doc_server, self._validation_server]
+        self._server = create_mcp_server()
 
-    async def _connect_server_with_timeout(self, server: MCPServer) -> None:
-        """Attempt to connect to an MCP server with retries."""
+    async def _connect_server_with_timeout(self) -> None:
+        """Attempt to connect to the MCP server with retries."""
         for attempt in range(3):
             try:
-                await asyncio.wait_for(server.connect(), timeout=20.0)  # type: ignore[no-untyped-call]
-                logging.info("Successfully connected to MCP server: %s", server.name)
+                await asyncio.wait_for(self._server.connect(), timeout=20.0)  # type: ignore[no-untyped-call]
+                logging.info("Successfully connected to MCP server: %s", self._server.name)
                 return
             except Exception as exc:  # pragma: no cover - network errors
                 if attempt == 2:
                     logging.warning(
-                        "Failed to connect MCP server %s: %s", server.name, exc
+                        "Failed to connect MCP server %s: %s", self._server.name, exc
                     )
                 else:
                     await asyncio.sleep(2**attempt)
 
     async def initialize(self) -> None:
-        """Connect all managed servers."""
-        for server in self._servers:
-            await self._connect_server_with_timeout(server)
+        """Connect the managed MCP server."""
+        await self._connect_server_with_timeout()
 
     async def cleanup(self) -> None:
-        """Disconnect all managed servers."""
-        for server in self._servers:
-            try:
-                await server.cleanup()  # type: ignore[no-untyped-call]
-            except Exception as exc:  # pragma: no cover - cleanup errors
-                logging.warning("Error cleaning MCP server %s: %s", server.name, exc)
+        """Disconnect the managed MCP server."""
+        try:
+            await self._server.cleanup()  # type: ignore[no-untyped-call]
+        except Exception as exc:  # pragma: no cover - cleanup errors
+            logging.warning("Error cleaning MCP server %s: %s", self._server.name, exc)
 
     def get_doc_server(self) -> MCPServer:
-        """Return the documentation server instance."""
-        return self._doc_server
+        """Return the MCP server instance."""
+        return self._server
 
     def get_validation_server(self) -> MCPServer:
-        """Return the validation server instance."""
-        return self._validation_server
+        """Return the MCP server instance."""
+        return self._server
 
 
 # Global manager instance used across the application

--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -9,8 +9,7 @@ from agents.mcp import MCPServerSse
 
 __all__ = [
     "MCPServerSse",
-    "create_mcp_documentation_server",
-    "create_mcp_validation_server",
+    "create_mcp_server",
     "run_erc_tool",
     "search_kicad_libraries",
     "search_kicad_footprints",
@@ -31,8 +30,7 @@ __all__ = [
     "search_kicad_libraries",
     "search_kicad_footprints",
     "extract_pin_details",
-    "create_mcp_documentation_server",
-    "create_mcp_validation_server",
+    "create_mcp_server",
     "run_erc",
     "run_erc_tool",
 ]
@@ -294,8 +292,8 @@ print(json.dumps(pins))
 
 
 
-def create_mcp_documentation_server() -> MCPServerSse:
-    """Create MCP server for SKiDL documentation.
+def create_mcp_server() -> MCPServerSse:
+    """Create MCP server connection used by all agents.
 
     Returns:
         MCPServerSse configured for the ``skidl_docs`` server.
@@ -304,26 +302,6 @@ def create_mcp_documentation_server() -> MCPServerSse:
     timeout = 15.0 if os.getenv("DOCKER_ENV") else 10.0
     return MCPServerSse(
         name="skidl_docs",
-        params={
-            "url": url,
-            "timeout": timeout,
-            "sse_read_timeout": timeout * 2,
-        },
-        cache_tools_list=True,
-        client_session_timeout_seconds=timeout,
-    )
-
-
-def create_mcp_validation_server() -> MCPServerSse:
-    """Create MCP server for hallucination validation.
-
-    Returns:
-        MCPServerSse configured for the ``skidl_validation`` server.
-    """
-    url = f"{settings.mcp_url}/sse"
-    timeout = 15.0 if os.getenv("DOCKER_ENV") else 10.0
-    return MCPServerSse(
-        name="skidl_validation",
         params={
             "url": url,
             "timeout": timeout,

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -6,23 +6,14 @@ from circuitron.mcp_manager import MCPManager
 
 
 def test_manager_connects_and_cleans_up() -> None:
-    doc_server = SimpleNamespace(connect=AsyncMock(), cleanup=AsyncMock(), name="doc")
-    val_server = SimpleNamespace(connect=AsyncMock(), cleanup=AsyncMock(), name="val")
+    server = SimpleNamespace(connect=AsyncMock(), cleanup=AsyncMock(), name="srv")
 
-    with (
-        patch(
-            "circuitron.mcp_manager.create_mcp_documentation_server",
-            return_value=doc_server,
-        ),
-        patch(
-            "circuitron.mcp_manager.create_mcp_validation_server",
-            return_value=val_server,
-        ),
+    with patch(
+        "circuitron.mcp_manager.create_mcp_server",
+        return_value=server,
     ):
         manager = MCPManager()
         asyncio.run(manager.initialize())
-        doc_server.connect.assert_awaited_once()
-        val_server.connect.assert_awaited_once()
+        server.connect.assert_awaited_once()
         asyncio.run(manager.cleanup())
-        doc_server.cleanup.assert_awaited_once()
-        val_server.cleanup.assert_awaited_once()
+        server.cleanup.assert_awaited_once()

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -24,7 +24,7 @@ async def run_wrappers() -> None:
          patch("circuitron.debug.Runner.run", AsyncMock()) as run_mock:
         run_mock.return_value = SimpleNamespace(final_output=PlanOutput())
         await pl.run_planner("p")
-        run_mock.assert_awaited_with(pl.planner, "p")  # type: ignore[attr-defined]
+        run_mock.assert_awaited_with(pl.planner, "p", max_turns=pl.settings.max_turns)  # type: ignore[attr-defined]
         run_mock.reset_mock()
 
         run_mock.return_value = SimpleNamespace(final_output=PlanEditorOutput(decision=PlanEditDecision(reasoning="x"), updated_plan=PlanOutput()))

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -136,27 +136,13 @@ def test_extract_pin_details_timeout() -> None:
         assert "error" in result.lower()
 
 
-def test_create_mcp_documentation_server() -> None:
+def test_create_mcp_server() -> None:
     cfg.setup_environment()
-    from circuitron.tools import create_mcp_documentation_server, MCPServerSse
+    from circuitron.tools import create_mcp_server, MCPServerSse
 
-    server = create_mcp_documentation_server()
+    server = create_mcp_server()
     assert isinstance(server, MCPServerSse)
     assert server.name == "skidl_docs"
-    assert server.params["url"] == cfg.settings.mcp_url + "/sse"
-    assert "timeout" in server.params
-    assert server.client_session_timeout_seconds == (
-        15.0 if os.getenv("DOCKER_ENV") else 10.0
-    )
-
-
-def test_create_mcp_validation_server() -> None:
-    cfg.setup_environment()
-    from circuitron.tools import create_mcp_validation_server, MCPServerSse
-
-    server = create_mcp_validation_server()
-    assert isinstance(server, MCPServerSse)
-    assert server.name == "skidl_validation"
     assert server.params["url"] == cfg.settings.mcp_url + "/sse"
     assert "timeout" in server.params
     assert server.client_session_timeout_seconds == (


### PR DESCRIPTION
## Summary
- collapse documentation/validation MCP servers into one server
- rename `create_mcp_documentation_server` -> `create_mcp_server`
- update manager and tests for new single server
- adjust pipeline wrapper test for max_turns parameter

## Testing
- `ruff check`
- `mypy circuitron`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686955aca2408333b1c45a5f84e2f4fa