### PR TITLE
Add knowledge graph usage guide tool

### DIFF
--- a/circuitron/agents.py
+++ b/circuitron/agents.py
@@ -36,6 +36,7 @@ from .tools import (
     search_kicad_footprints,
     extract_pin_details,
     run_erc_tool,
+    get_kg_usage_guide,
 )
 from .mcp_manager import mcp_manager
 
@@ -153,12 +154,14 @@ def create_code_validation_agent() -> Agent:
         tool_choice=_tool_choice_for_mcp(settings.code_validation_model)
     )
 
+    tools: list[Tool] = [get_kg_usage_guide]
+
     return Agent(
         name="Circuitron-Validator",
         instructions=CODE_VALIDATION_PROMPT,
         model=settings.code_validation_model,
         output_type=CodeValidationOutput,
-        tools=[],
+        tools=tools,
         mcp_servers=[mcp_manager.get_validation_server()],
         model_settings=model_settings,
         handoff_description="Validate SKiDL code",
@@ -171,7 +174,7 @@ def create_code_correction_agent() -> Agent:
         tool_choice=_tool_choice_for_mcp(settings.code_validation_model)
     )
 
-    tools: list[Tool] = [run_erc_tool]
+    tools: list[Tool] = [run_erc_tool, get_kg_usage_guide]
 
     return Agent(
         name="Circuitron-Corrector",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -89,6 +89,20 @@ def test_code_corrector_configuration() -> None:
     assert "run_erc" in tool_names
 
 
+def test_agents_include_kg_guide_tool() -> None:
+    import sys
+
+    sys.modules.pop("circuitron.agents", None)
+    import circuitron.config as cfg
+
+    cfg.setup_environment()
+    mod = importlib.import_module("circuitron.agents")
+    validator_tools = [t.name for t in mod.code_validator.tools]
+    corrector_tools = [t.name for t in mod.code_corrector.tools]
+    assert "get_kg_usage_guide" in validator_tools
+    assert "get_kg_usage_guide" in corrector_tools
+
+
 def test_tool_choice_auto_for_o4mini() -> None:
     import sys
 


### PR DESCRIPTION
## Summary
- implement `get_kg_usage_guide` tool returning example knowledge graph queries
- expose tool and use in code validation/correction agents
- add tests for the guide tool and agent registration

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce53a79cc833397afd2dee3900748