### PR TITLE
feat: enhance correction input context with design info (Task 3)

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -233,7 +233,15 @@ def test_run_code_correction_cleanup(tmp_path: Path) -> None:
 
     with patch("circuitron.pipeline.write_temp_skidl_script") as write_mock:
         with patch("circuitron.debug.Runner.run", AsyncMock(return_value=SimpleNamespace(final_output=correction_out))):
-            asyncio.run(pl.run_code_correction(code_out, validation))
+            asyncio.run(
+                pl.run_code_correction(
+                    code_out,
+                    validation,
+                    PlanOutput(),
+                    PartSelectionOutput(),
+                    DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok"),
+                )
+            )
         write_mock.assert_not_called()
 
 

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -52,7 +52,13 @@ async def run_wrappers() -> None:
         run_mock.reset_mock()
 
         run_mock.return_value = SimpleNamespace(final_output=CodeCorrectionOutput(corrected_code="fixed", validation_notes=""))
-        await pl.run_code_correction(CodeGenerationOutput(complete_skidl_code="code"), CodeValidationOutput(status="fail", summary="bad"))
+        await pl.run_code_correction(
+            CodeGenerationOutput(complete_skidl_code="code"),
+            CodeValidationOutput(status="fail", summary="bad"),
+            PlanOutput(),
+            PartSelectionOutput(),
+            DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok"),
+        )
 
 
 def test_wrapper_functions() -> None:

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -71,7 +71,14 @@ def test_format_code_validation_and_correction_input() -> None:
     pin = PinDetail(number="1", name="VCC", function="pwr")
     part = SelectedPart(name="U1", library="lib", footprint="fp", pin_details=[pin])
     selection = PartSelectionOutput(selections=[part])
-    docs = cast(DocumentationOutput, SimpleNamespace(documentation_findings=["doc"]))
+    docs = cast(
+        DocumentationOutput,
+        SimpleNamespace(
+            research_queries=[],
+            documentation_findings=["doc"],
+            implementation_readiness="ok",
+        ),
+    )
     val = CodeValidationOutput(
         status="fail",
         summary="bad",
@@ -79,7 +86,14 @@ def test_format_code_validation_and_correction_input() -> None:
     )
     text = format_code_validation_input("print('hi')", selection, docs)
     assert "print('hi')" in text and "U1" in text and "doc" in text
-    corr = format_code_correction_input("print('hi')", val, {"erc_passed": False})
+    corr = format_code_correction_input(
+        "print('hi')",
+        val,
+        PlanOutput(),
+        selection,
+        docs,
+        {"erc_passed": False},
+    )
     assert "Validation Summary: bad" in corr
     assert "erc_passed" in corr
 


### PR DESCRIPTION
## Summary
- add helper functions to summarize plan, component selection and docs
- enrich code correction context with design plan, component and documentation info
- update pipeline to pass richer context
- adjust unit tests for new function signatures

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf72aeb2c833393e366c27313ad04