### PR TITLE
feat: separate validation and ERC correction phases (Task 5)

### DIFF
--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -619,3 +619,47 @@ def format_code_correction_input(
         "Apply iterative corrections until validation passes and ERC shows zero errors."
     )
     return "\n".join(parts)
+
+
+def format_code_correction_validation_input(
+    script_content: str,
+    validation: CodeValidationOutput,
+    plan: PlanOutput,
+    selection: PartSelectionOutput,
+    docs: DocumentationOutput,
+) -> str:
+    """Format input for validation-only code correction."""
+
+    text = format_code_correction_input(
+        script_content,
+        validation,
+        plan,
+        selection,
+        docs,
+        None,
+    )
+    return text + "\nFocus only on fixing validation issues. Ignore ERC results."
+
+
+def format_code_correction_erc_input(
+    script_content: str,
+    validation: CodeValidationOutput,
+    plan: PlanOutput,
+    selection: PartSelectionOutput,
+    docs: DocumentationOutput,
+    erc_result: dict[str, object] | None,
+) -> str:
+    """Format input for ERC-only code correction."""
+
+    text = format_code_correction_input(
+        script_content,
+        validation,
+        plan,
+        selection,
+        docs,
+        erc_result,
+    )
+    return (
+        text
+        + "\nValidation has passed. Use the run_erc_tool as needed and fix ERC violations only."
+    )

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -48,16 +48,33 @@ async def run_wrappers() -> None:
         run_mock.reset_mock()
 
         run_mock.return_value = SimpleNamespace(final_output=CodeValidationOutput(status="pass", summary="ok"))
-        await pl.run_code_validation(CodeGenerationOutput(complete_skidl_code="code"), PartSelectionOutput(), DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok"))
+        await pl.run_code_validation(
+            CodeGenerationOutput(complete_skidl_code="code"),
+            PartSelectionOutput(),
+            DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok"),
+        )
         run_mock.reset_mock()
 
         run_mock.return_value = SimpleNamespace(final_output=CodeCorrectionOutput(corrected_code="fixed", validation_notes=""))
-        await pl.run_code_correction(
+        await pl.run_code_correction_validation_only(
             CodeGenerationOutput(complete_skidl_code="code"),
             CodeValidationOutput(status="fail", summary="bad"),
             PlanOutput(),
             PartSelectionOutput(),
             DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok"),
+        )
+        run_mock.reset_mock()
+
+        run_mock.return_value = SimpleNamespace(
+            final_output=CodeCorrectionOutput(corrected_code="fixed", validation_notes="")
+        )
+        await pl.run_code_correction_erc_only(
+            CodeGenerationOutput(complete_skidl_code="code"),
+            CodeValidationOutput(status="pass", summary="ok"),
+            PlanOutput(),
+            PartSelectionOutput(),
+            DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok"),
+            {},
         )
 
 


### PR DESCRIPTION
## Summary
- split validation and ERC loops in the pipeline
- add phase-specific code correction helpers
- update run_code_validation to optionally skip ERC
- expose new input formatting utilities for each phase
- adjust tests for the new behaviour

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cfc27b670833396ee921069a8338e