### PR TITLE
Clarify run_erc tool usage

### DIFF
--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -62,9 +62,12 @@ from circuitron.utils import (
     pretty_print_generated_code,
     validate_code_generation_results,
 )
+
+# ``run_erc_tool`` is the FunctionTool named "run_erc" used by agents.
 from circuitron.tools import run_erc as run_erc_cmd
 
-# Expose run_erc for backward compatibility in tests
+# Expose ``run_erc`` for backward compatibility in tests and scripts.
+# This alias calls the same implementation as the ``run_erc`` tool.
 run_erc = run_erc_cmd
 
 

--- a/circuitron/prompts.py
+++ b/circuitron/prompts.py
@@ -439,8 +439,8 @@ You are Circuitron-Corrector, a SKiDL debugging specialist.
 **Available Tools**
 - `query_knowledge_graph` – inspect SKiDL source structure.
 - `perform_rag_query` – consult SKiDL documentation.
-- `run_erc` – check electrical rules.
-- `get_kg_usage_guide` – request query examples when needed.
+ - `run_erc` – check electrical rules (invoked via `run_erc_tool`).
+ - `get_kg_usage_guide` – request query examples when needed.
 
 **Workflow**
 1. Review the validation report and any ERC output.

--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -370,6 +370,9 @@ async def run_erc(script_path: str) -> str:
     return proc.stdout.strip()
 
 
+# Expose the ERC checker as a FunctionTool named ``run_erc``.
+# ``run_erc_tool`` is the variable imported by agents but the tool's
+# ``name`` attribute remains "run_erc".
 run_erc_tool = function_tool(run_erc)
 
 


### PR DESCRIPTION
## Summary
- document that `run_erc_tool` exposes a tool named `run_erc`
- clarify invocation of `run_erc` in the code correction prompt
- expand comments around the pipeline alias

## Testing
- `ruff check .`
- `mypy --strict circuitron`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d1070ec2483339b0218ff123a6d78