### PR TITLE
Update sanitize_text to keep newlines and add tests

### DIFF
--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -24,7 +24,7 @@ from .correction_context import CorrectionContext
 def sanitize_text(text: str, max_length: int = 10000) -> str:
     """Return a cleaned version of ``text`` limited to ``max_length`` characters."""
 
-    cleaned = "".join(ch for ch in text if ch.isprintable())
+    cleaned = "".join(ch for ch in text if ch.isprintable() or ch in "\n\r\t")
     cleaned = cleaned.replace("```", "'''")
     return cleaned.strip()[:max_length]
 

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -166,3 +166,19 @@ def test_get_kg_usage_guide() -> None:
         cast(Coroutine[Any, Any, str], get_kg_usage_guide.on_invoke_tool(ctx, args))
     )
     assert "method" in guide and "query_knowledge_graph" in guide
+
+
+def test_sanitize_text_multiline() -> None:
+    from circuitron.utils import sanitize_text
+
+    text = "hello\nworld\t!\rtest"
+    cleaned = sanitize_text(text)
+    assert cleaned == text
+
+
+def test_sanitize_text_removes_nonprintable() -> None:
+    from circuitron.utils import sanitize_text
+
+    text = "bad\x00text"
+    cleaned = sanitize_text(text)
+    assert "\x00" not in cleaned


### PR DESCRIPTION
## Summary
- allow sanitize_text to keep \n, \t and \r characters
- add unit tests for multiline text preservation and non-printable character removal

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1c5913608333bc7b228e1248baca