### PR TITLE
Add final script execution and ERC-only validation

### DIFF
--- a/tests/test_part_selection.py
+++ b/tests/test_part_selection.py
@@ -34,7 +34,8 @@ async def fake_pipeline_no_feedback() -> None:
          patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
          patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
          patch.object(pl, "run_code_validation", AsyncMock(return_value=(CodeValidationOutput(status="pass", summary="ok"), {"erc_passed": True}))), \
-         patch.object(pl, "collect_user_feedback", return_value=UserFeedback()):
+         patch.object(pl, "collect_user_feedback", return_value=UserFeedback()), \
+         patch.object(pl, "execute_final_script", AsyncMock(return_value="{}")):
         result = await pl.pipeline("test")
     assert result is code_out
 
@@ -61,7 +62,8 @@ async def fake_pipeline_edit_plan() -> None:
          patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
          patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
          patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
-         patch.object(pl, "run_code_validation", AsyncMock(return_value=(CodeValidationOutput(status="pass", summary="ok"), {"erc_passed": True}))):
+         patch.object(pl, "run_code_validation", AsyncMock(return_value=(CodeValidationOutput(status="pass", summary="ok"), {"erc_passed": True}))), \
+         patch.object(pl, "execute_final_script", AsyncMock(return_value="{}")):
         result = await pl.pipeline("test")
     assert result is code_out
 

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -182,3 +182,14 @@ def test_sanitize_text_removes_nonprintable() -> None:
     text = "bad\x00text"
     cleaned = sanitize_text(text)
     assert "\x00" not in cleaned
+
+
+def test_prepare_erc_only_script() -> None:
+    from circuitron.utils import prepare_erc_only_script
+
+    script = "from skidl import *\ngenerate_netlist()\nERC()\n"
+    result = prepare_erc_only_script(script)
+    assert "# generate_netlist()" in result
+    lines = [l.strip() for l in result.splitlines() if not l.strip().startswith("#")]
+    assert "generate_netlist()" not in lines
+    assert "ERC()" in lines


### PR DESCRIPTION
## Summary
- support volume mounts and new helpers in `DockerSession`
- add `prepare_erc_only_script` and output directory helper
- execute full SKiDL script via `execute_final_script` tool
- integrate final script execution in pipeline
- cover new behaviour in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d23d3f1808333bb297c5b2dcc9be7