### PR TITLE
Implement get_erc_info tool and streamline CODE_CORRECTION_PROMPT

### DIFF
--- a/circuitron/agents.py
+++ b/circuitron/agents.py
@@ -37,6 +37,7 @@ from .tools import (
     extract_pin_details,
     run_erc_tool,
     get_kg_usage_guide,
+    get_erc_info,
 )
 from .mcp_manager import mcp_manager
 
@@ -174,7 +175,7 @@ def create_code_correction_agent() -> Agent:
         tool_choice=_tool_choice_for_mcp(settings.code_validation_model)
     )
 
-    tools: list[Tool] = [run_erc_tool, get_kg_usage_guide]
+    tools: list[Tool] = [run_erc_tool, get_kg_usage_guide, get_erc_info]
 
     return Agent(
         name="Circuitron-Corrector",

--- a/circuitron/prompts.py
+++ b/circuitron/prompts.py
@@ -443,9 +443,10 @@ You are Circuitron-Corrector, a SKiDL debugging specialist.
 
 **Available Tools**
 - `query_knowledge_graph` – inspect SKiDL source structure
-- `perform_rag_query` – consult SKiDL documentation  
+- `perform_rag_query` – consult SKiDL documentation
 - `run_erc` – check electrical rules (invoked via `run_erc_tool`)
 - `get_kg_usage_guide` – request query examples when needed
+- `get_erc_info` – retrieve ERC troubleshooting guidance
 
 **CRITICAL: Two-Phase Correction Process**
 
@@ -455,10 +456,12 @@ You are Circuitron-Corrector, a SKiDL debugging specialist.
 - Input will specify: "Focus only on fixing validation issues. Ignore ERC results."
 - Continue until validation status becomes "pass"
 
-**Phase 2: ERC ONLY** 
+**Phase 2: ERC ONLY**
 - Only activated AFTER validation passes completely
-- Focus EXCLUSIVELY on electrical rules violations  
+- Focus EXCLUSIVELY on electrical rules violations
 - Input will specify: "Validation has passed. Use the run_erc_tool as needed and fix ERC violations only."
+- Use `get_erc_info("all")` for a full ERC guide when starting this phase
+- Call `get_erc_info` with categories like "unconnected" or "drive" for targeted help
 - Use `run_erc_tool` to check electrical rules and fix violations iteratively
 
 **Correction Workflow**
@@ -468,31 +471,11 @@ You are Circuitron-Corrector, a SKiDL debugging specialist.
    - Resolved vs. remaining issues
    - Failed strategies to avoid repeating
 3. **Phase-Specific Research**:
-   - **Validation Phase**: Use `query_knowledge_graph` and `get_kg_usage_guide` for API validation
-   - **ERC Phase**: Use `perform_rag_query` for ERC patterns and run `run_erc_tool` for testing
+  - **Validation Phase**: Use `query_knowledge_graph` and `get_kg_usage_guide` for API validation
+  - **ERC Phase**: Call `get_erc_info` for guidance, use `perform_rag_query` for additional patterns, and run `run_erc_tool` for testing
 4. **Apply Targeted Fixes**: Focus only on current phase issues
 5. **Context Awareness**: Avoid repeating failed strategies from correction context
 
-**Critical ERC Knowledge (Phase 2 Only):**
-
-**Unconnected Pin Handling:**
-- Use `NC` for intentional no-connects: `part[1,3,4] += NC`
-- Bulk no-connect unused pins: `part[:] += NC`, then connect used ones
-- NC pins auto-disconnect when connected to real nets: `part[5] += Net()`
-
-**Power Drive Requirements:**
-- Power supply nets need drive: `vcc.drive = POWER`, `gnd.drive = POWER`
-- Output pins powering others: `output_pin.drive = POWER`
-- Example: `regulator[1].drive = POWER` when pin 1 powers another chip
-
-**ERC Suppression (Use Sparingly):**
-- Suppress net warnings: `net.do_erc = False`
-- Suppress specific pin: `part[5].do_erc = False`
-- Suppress entire part: `part.do_erc = False`
-
-**Footprint Issues:**
-- Assign missing footprints: `part.footprint = "LibraryName:FootprintName"`
-- Use empty footprint handler for generic parts if appropriate
 
 **Knowledge Graph Usage:**
 - When uncertain about query syntax: `get_kg_usage_guide("examples")`

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -103,6 +103,18 @@ def test_agents_include_kg_guide_tool() -> None:
     assert "get_kg_usage_guide" in corrector_tools
 
 
+def test_corrector_includes_erc_info_tool() -> None:
+    import sys
+
+    sys.modules.pop("circuitron.agents", None)
+    import circuitron.config as cfg
+
+    cfg.setup_environment()
+    mod = importlib.import_module("circuitron.agents")
+    corrector_tools = [t.name for t in mod.code_corrector.tools]
+    assert "get_erc_info" in corrector_tools
+
+
 def test_tool_choice_auto_for_o4mini() -> None:
     import sys
 

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -168,6 +168,21 @@ def test_get_kg_usage_guide() -> None:
     assert "method" in guide and "query_knowledge_graph" in guide
 
 
+def test_get_erc_info() -> None:
+    from circuitron.tools import get_erc_info
+    from agents.tool_context import ToolContext
+    import json
+    import asyncio
+    from typing import Any, Coroutine, cast
+
+    ctx = ToolContext(context=None, tool_call_id="erc1")
+    args = json.dumps({"issue_type": "drive"})
+    info = asyncio.run(
+        cast(Coroutine[Any, Any, str], get_erc_info.on_invoke_tool(ctx, args))
+    )
+    assert "drive" in info and "POWER" in info
+
+
 def test_sanitize_text_multiline() -> None:
     from circuitron.utils import sanitize_text
 
@@ -190,6 +205,6 @@ def test_prepare_erc_only_script() -> None:
     script = "from skidl import *\ngenerate_netlist()\nERC()\n"
     result = prepare_erc_only_script(script)
     assert "# generate_netlist()" in result
-    lines = [l.strip() for l in result.splitlines() if not l.strip().startswith("#")]
+    lines = [line.strip() for line in result.splitlines() if not line.strip().startswith("#")]
     assert "generate_netlist()" not in lines
     assert "ERC()" in lines


### PR DESCRIPTION
## Summary
- add `get_erc_info` function exposing ERC troubleshooting guidance
- export the new tool and include in the correction agent
- update CODE_CORRECTION_PROMPT to rely on `get_erc_info`
- test new tool and agent configuration

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d3b6e75dc8333a779d8e5aaecf6d8