### PR TITLE
Fix Windows path handling for Docker volumes

### DIFF
--- a/circuitron/docker_session.py
+++ b/circuitron/docker_session.py
@@ -7,6 +7,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 import threading
+from .utils import convert_windows_path_for_docker
 
 
 def cleanup_stale_containers(prefix: str) -> None:
@@ -127,7 +128,11 @@ class DockerSession:
                 self.container_name,
             ]
             for host, container in self.volumes.items():
-                cmd.extend(["-v", f"{host}:{container}"])
+                try:
+                    cont_path = convert_windows_path_for_docker(container)
+                except ValueError:
+                    cont_path = container
+                cmd.extend(["-v", f"{host}:{cont_path}"])
             cmd += [
                 self.image,
                 "sleep",

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -35,6 +35,7 @@ from circuitron.utils import (
     collect_user_feedback,
     pretty_print_validation,
     write_temp_skidl_script,
+    convert_windows_path_for_docker,
 )
 
 
@@ -249,3 +250,11 @@ def test_prepare_erc_only_script() -> None:
     lines = [line.strip() for line in result.splitlines() if not line.strip().startswith("#")]
     assert "generate_netlist()" not in lines
     assert "ERC()" in lines
+
+
+def test_convert_windows_path_for_docker() -> None:
+    path = convert_windows_path_for_docker("C:\\Users\\bob")
+    assert path == "/mnt/c/Users/bob"
+    assert convert_windows_path_for_docker("/mnt/c/Users") == "/mnt/c/Users"
+    with pytest.raises(ValueError):
+        convert_windows_path_for_docker("not/a/windows/path")


### PR DESCRIPTION
## Summary
- ensure Windows paths convert to `/mnt/<drive>` format for Docker
- mount converted paths when running final script
- apply conversion within DockerSession start
- test path converter and Windows volume handling

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e320d46908333bd0bf1dc2c02229b