### PR TITLE
Remove dead ERC code and rename validation correction

### DIFF
--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -765,31 +765,6 @@ def format_code_correction_validation_input(
     return text + "\nFocus only on fixing validation issues. Ignore ERC results."
 
 
-def format_code_correction_erc_input(
-    script_content: str,
-    validation: CodeValidationOutput,
-    plan: PlanOutput,
-    selection: PartSelectionOutput,
-    docs: DocumentationOutput,
-    erc_result: dict[str, object] | None,
-    context: CorrectionContext | None = None,
-) -> str:
-    """Format input for ERC-only code correction."""
-
-    text = format_code_correction_input(
-        script_content,
-        validation,
-        plan,
-        selection,
-        docs,
-        erc_result,
-        context,
-    )
-    return (
-        text
-        + "\nValidation has passed. Use the run_erc_tool as needed and fix ERC violations only."
-    )
-
 
 def format_erc_handling_input(
     script_content: str,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -164,7 +164,7 @@ async def fake_pipeline_with_correction() -> None:
          ), \
          patch.object(
              pl,
-             "run_code_correction_validation_only",
+             "run_validation_correction",
              AsyncMock(return_value=corrected),
          ), \
          patch.object(
@@ -240,7 +240,7 @@ async def fake_pipeline_edit_plan_with_correction() -> None:
          patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
          patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
          patch.object(pl, "run_code_validation", AsyncMock(side_effect=[val_fail, val_pass, val_ok])), \
-         patch.object(pl, "run_code_correction_validation_only", AsyncMock(return_value=corrected)), \
+         patch.object(pl, "run_validation_correction", AsyncMock(return_value=corrected)), \
          patch.object(
              pl,
              "run_erc_handling",
@@ -356,7 +356,7 @@ async def fake_pipeline_validation_error() -> None:
          patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
          patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
          patch.object(pl, "run_code_validation", AsyncMock(return_value=val_fail)), \
-         patch.object(pl, "run_code_correction_validation_only", AsyncMock(return_value=code_out)), \
+         patch.object(pl, "run_validation_correction", AsyncMock(return_value=code_out)), \
          patch.object(pl, "collect_user_feedback", return_value=UserFeedback()):
         with pytest.raises(pl.PipelineError):
             await pl.pipeline("test")
@@ -435,7 +435,7 @@ async def fake_pipeline_debug_failure(capsys: pytest.CaptureFixture[str]) -> str
          patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
          patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
          patch.object(pl, "run_code_validation", AsyncMock(return_value=val_fail)), \
-         patch.object(pl, "run_code_correction_validation_only", AsyncMock(return_value=code_out)), \
+         patch.object(pl, "run_validation_correction", AsyncMock(return_value=code_out)), \
          patch.object(pl, "collect_user_feedback", return_value=UserFeedback()):
         pl.settings.dev_mode = True
         with pytest.raises(pl.PipelineError):

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -56,7 +56,7 @@ async def run_wrappers() -> None:
         run_mock.reset_mock()
 
         run_mock.return_value = SimpleNamespace(final_output=CodeCorrectionOutput(corrected_code="fixed", validation_notes=""))
-        await pl.run_code_correction_validation_only(
+        await pl.run_validation_correction(
             CodeGenerationOutput(complete_skidl_code="code"),
             CodeValidationOutput(status="fail", summary="bad"),
             PlanOutput(),


### PR DESCRIPTION
## Summary
- drop unused ERC-only code formatting and wrapper
- rename `run_code_correction_validation_only` to `run_validation_correction`
- update pipeline exports and tests

## Testing
- `ruff check .`
- `mypy --strict circuitron`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f27c86e048333b9166bf021cee64c