### PR TITLE
Fix critical runtime error correction bugs and enhance code quality

### DIFF
--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -348,8 +348,10 @@ async def run_runtime_check(script_path: str) -> str:
 
         try:
             with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
-                runpy.run_path('/tmp/script.py', run_name='__main__')
-                if 'default_circuit' in globals():
+                script_globals = runpy.run_path('/tmp/script.py', run_name='__main__')
+                if 'default_circuit' in script_globals or any(
+                    'Circuit' in str(type(v)) for v in script_globals.values()
+                ):
                     print('Circuit object created successfully')
         except Exception as exc:
             success = False

--- a/tests/test_correction_context.py
+++ b/tests/test_correction_context.py
@@ -35,3 +35,13 @@ def test_erc_summary_and_issue_tracking() -> None:
     assert "Attempt 1" in summary
     assert "WARNING: w" in summary
     assert ctx.erc_issue_types["WARNING"] == 1
+
+
+def test_runtime_attempt_handling() -> None:
+    ctx = CorrectionContext(max_attempts=2)
+    err = {"success": False, "error_details": "boom"}
+    ctx.add_runtime_attempt(err, ["fix1"])
+    assert ctx.runtime_attempts == 1
+    assert ctx.should_continue_runtime_attempts()
+    ctx.add_runtime_attempt(err, ["fix2"])
+    assert not ctx.should_continue_runtime_attempts()


### PR DESCRIPTION
## Summary
- fix incorrect globals() check in `run_runtime_check`
- harden runtime correction loop against agent failures
- add runtime check unit tests and context tests
- add runtime check pipeline tests
- skip runtime check when Docker is unavailable

## Testing
- `pytest tests/test_tools.py::test_prepare_runtime_check_script tests/test_tools.py::test_run_runtime_check_success tests/test_tools.py::test_run_runtime_check_failure tests/test_correction_context.py::test_runtime_attempt_handling tests/test_pipeline.py::test_run_runtime_check_and_correction tests/test_pipeline.py::test_runtime_agent_failure_handled -q`

------
https://chatgpt.com/codex/tasks/task_e_686fe575b5448333bd0f274efb318b90