### PR TITLE
Fix undefined kicad_session in tools

### DIFF
--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -40,7 +40,7 @@ __all__ = [
 
 
 container_name = f"circuitron-kicad-{os.getpid()}"
-kicad_session = DockerSession(settings.kicad_image, container_name)
+kicad_session: DockerSession = DockerSession(settings.kicad_image, container_name)
 
 
 @function_tool
@@ -516,7 +516,7 @@ set_default_tool(KICAD5)
         # Copy generated files from container to host directory
         if success:
             # Copy all files from the container's working directory to the output directory
-            copied_files = session.copy_generated_files("/workspace/*", output_dir)
+            session.copy_generated_files("/workspace/*", output_dir)
             files = sorted(os.listdir(output_dir))
         else:
             files = []


### PR DESCRIPTION
## Summary
- add explicit type for global `kicad_session` in `tools.py`
- remove unused variable in final script execution

## Testing
- `ruff check circuitron/tools.py`
- `mypy circuitron/tools.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'circuitron')*

------
https://chatgpt.com/codex/tasks/task_e_686fe6dea4dc83339caae34454e0beb3