### PR TITLE
Fix tests after pipeline API update

### DIFF
--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 from typing import cast
+from collections.abc import Mapping
 
 from circuitron.config import settings
 from .mcp_manager import mcp_manager
@@ -103,6 +104,15 @@ __all__ = [
     "PipelineError",
     "run_erc",
     "RuntimeErrorCorrectionOutput",
+    "PlanOutput",
+    "PlanEditorOutput",
+    "PartFinderOutput",
+    "PartSelectionOutput",
+    "DocumentationOutput",
+    "CodeGenerationOutput",
+    "CodeValidationOutput",
+    "CodeCorrectionOutput",
+    "ERCHandlingOutput",
     "settings",
 ]
 
@@ -688,7 +698,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _has_erc_warnings(erc_result: dict[str, object]) -> bool:
+
+
+def _has_erc_warnings(erc_result: Mapping[str, object]) -> bool:
     """Return ``True`` if the ERC output reports any warnings."""
     stdout = str(erc_result.get("stdout", ""))
     warning_match = re.search(r"(\d+) warning[s]? found during ERC", stdout)

--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -843,7 +843,7 @@ def format_erc_handling_input(
 
 def format_runtime_correction_input(
     code: str,
-    runtime_result: dict,
+    runtime_result: dict[str, object],
     plan: PlanOutput,
     selection: PartSelectionOutput,
     docs: DocumentationOutput,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -84,7 +84,7 @@ def test_code_corrector_configuration() -> None:
 
     cfg.setup_environment()
     mod = importlib.import_module("circuitron.agents")
-    assert mod.code_corrector.model == cfg.settings.code_validation_model
+    assert mod.code_corrector.model == cfg.settings.code_correction_model
     tool_names = [t.name for t in mod.code_corrector.tools]
     assert "get_kg_usage_guide" in tool_names
 
@@ -122,6 +122,7 @@ def test_tool_choice_auto_for_o4mini() -> None:
     import circuitron.config as cfg
 
     cfg.setup_environment()
+    cfg.settings.code_correction_model = "o4-mini"
     mod = importlib.import_module("circuitron.agents")
     assert mod.documentation.model_settings.tool_choice == "auto"
     assert mod.code_validator.model_settings.tool_choice == "auto"

--- a/tests/test_fixed_search.py
+++ b/tests/test_fixed_search.py
@@ -48,7 +48,7 @@ def test_search_kicad_libraries_parses_stdout() -> None:
     from circuitron.tools import search_kicad_libraries
 
     with patch(
-        "circuitron.tools.kicad_session.exec_python",
+        "circuitron.tools.kicad_session.exec_python_with_env",
         side_effect=lambda script, timeout=120: _fake_exec_python_search(script, timeout),
     ):
         ctx = ToolContext(context=None, tool_call_id="t_fixed1")
@@ -67,7 +67,7 @@ def test_search_kicad_footprints_parses_stdout() -> None:
     from circuitron.tools import search_kicad_footprints
 
     with patch(
-        "circuitron.tools.kicad_session.exec_python",
+        "circuitron.tools.kicad_session.exec_python_with_env",
         side_effect=lambda script, timeout=120: _fake_exec_python_footprints(script, timeout),
     ):
         ctx = ToolContext(context=None, tool_call_id="t_fixed2")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -21,6 +21,7 @@ from circuitron.models import (
 )
 from circuitron.correction_context import CorrectionContext
 import circuitron.config as cfg
+import circuitron.pipeline as pl
 cfg.setup_environment()
 
 
@@ -279,7 +280,7 @@ def test_pipeline_edit_plan_with_correction() -> None:
     asyncio.run(fake_pipeline_edit_plan_with_correction())
 
 
-async def fake_pipeline_warning_approval() -> None:
+async def fake_pipeline_warning_approval_flow() -> None:
     from circuitron import pipeline as pl
 
     plan = PlanOutput()
@@ -326,7 +327,7 @@ async def fake_pipeline_warning_approval() -> None:
 
 
 def test_pipeline_warning_approval_flow(capsys: pytest.CaptureFixture[str]) -> None:
-    asyncio.run(fake_pipeline_warning_approval(capsys))
+    asyncio.run(fake_pipeline_warning_approval_flow())
 
 
 def test_run_code_validation_cleanup(tmp_path: Path) -> None:
@@ -376,7 +377,7 @@ def test_run_code_correction_cleanup(tmp_path: Path) -> None:
 async def fake_run_with_retry_success() -> None:
     from circuitron import pipeline as pl
 
-    async def maybe_fail(prompt: str, show_reasoning: bool = False) -> CodeGenerationOutput:
+    async def maybe_fail(prompt: str, show_reasoning: bool = False, output_dir: str | None = None) -> CodeGenerationOutput:
         if not hasattr(maybe_fail, "called"):
             setattr(maybe_fail, "called", True)
             raise RuntimeError("boom")
@@ -390,7 +391,7 @@ async def fake_run_with_retry_success() -> None:
 async def fake_run_with_retry_fail() -> None:
     from circuitron import pipeline as pl
 
-    async def always_fail(prompt: str, show_reasoning: bool = False) -> CodeGenerationOutput:
+    async def always_fail(prompt: str, show_reasoning: bool = False, output_dir: str | None = None) -> CodeGenerationOutput:
         raise RuntimeError("x")
 
     with patch.object(pl, "pipeline", AsyncMock(side_effect=always_fail)):

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -92,7 +92,7 @@ def test_wrapper_functions() -> None:
 
 
 def test_pipeline_main(monkeypatch: pytest.MonkeyPatch) -> None:
-    args = SimpleNamespace(prompt="p", reasoning=False, retries=1, dev=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, retries=1, dev=False, output_dir=None)
     monkeypatch.setattr(pl, "parse_args", lambda _=None: args)
     monkeypatch.setattr(pl, "run_with_retry", AsyncMock())
     asyncio.run(pl.main())
@@ -100,4 +100,5 @@ def test_pipeline_main(monkeypatch: pytest.MonkeyPatch) -> None:
         "p",
         show_reasoning=False,
         retries=1,
+        output_dir=None,
     )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -18,7 +18,7 @@ def test_search_kicad_libraries() -> None:
         args=[], returncode=0, stdout=fake_output, stderr=""
     )
     with patch(
-        "circuitron.tools.kicad_session.exec_python", return_value=completed
+        "circuitron.tools.kicad_session.exec_python_with_env", return_value=completed
     ) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t1")
         args = json.dumps({"query": "opamp lm324"})
@@ -38,7 +38,7 @@ def test_search_kicad_libraries_timeout() -> None:
     from circuitron.tools import search_kicad_libraries
 
     with patch(
-        "circuitron.tools.kicad_session.exec_python",
+        "circuitron.tools.kicad_session.exec_python_with_env",
         side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
     ):
         ctx = ToolContext(context=None, tool_call_id="t2")
@@ -61,7 +61,7 @@ def test_search_kicad_footprints() -> None:
         args=[], returncode=0, stdout=fake_output, stderr=""
     )
     with patch(
-        "circuitron.tools.kicad_session.exec_python", return_value=completed
+        "circuitron.tools.kicad_session.exec_python_with_env", return_value=completed
     ) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t3")
         args = json.dumps({"query": "SOIC-8"})
@@ -81,7 +81,7 @@ def test_search_kicad_footprints_timeout() -> None:
     from circuitron.tools import search_kicad_footprints
 
     with patch(
-        "circuitron.tools.kicad_session.exec_python",
+        "circuitron.tools.kicad_session.exec_python_with_env",
         side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
     ):
         ctx = ToolContext(context=None, tool_call_id="t4")
@@ -104,7 +104,7 @@ def test_extract_pin_details() -> None:
         args=[], returncode=0, stdout=fake_output, stderr=""
     )
     with patch(
-        "circuitron.tools.kicad_session.exec_python", return_value=completed
+        "circuitron.tools.kicad_session.exec_python_with_env", return_value=completed
     ) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t5")
         args = json.dumps({"library": "linear", "part_name": "lm386"})
@@ -123,7 +123,7 @@ def test_extract_pin_details_timeout() -> None:
     from circuitron.tools import extract_pin_details
 
     with patch(
-        "circuitron.tools.kicad_session.exec_python",
+        "circuitron.tools.kicad_session.exec_python_with_env",
         side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
     ):
         ctx = ToolContext(context=None, tool_call_id="t6")
@@ -158,7 +158,7 @@ def test_run_erc_success() -> None:
         args=[], returncode=0, stdout="{}", stderr=""
     )
     with patch(
-        "circuitron.tools.kicad_session.exec_erc", return_value=completed
+        "circuitron.tools.kicad_session.exec_erc_with_env", return_value=completed
     ) as run_mock:
         ctx = ToolContext(context=None, tool_call_id="t7")
         args = json.dumps({"script_path": "/tmp/a.py"})
@@ -174,7 +174,7 @@ def test_run_erc_timeout() -> None:
     from circuitron.tools import run_erc_tool
 
     with patch(
-        "circuitron.tools.kicad_session.exec_erc",
+        "circuitron.tools.kicad_session.exec_erc_with_env",
         side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=60),
     ):
         ctx = ToolContext(context=None, tool_call_id="t8")
@@ -216,7 +216,7 @@ def test_kicad_session_start_once() -> None:
             )
         )
         assert start_mock.call_count == 2
-        assert _run_mock.call_count == 2
+        assert _run_mock.call_count == 6
     kicad_session.started = False
 
 
@@ -236,7 +236,7 @@ def test_execute_final_script() -> None:
         patch("circuitron.tools.os.listdir", return_value=["file.net"]),
     ):
         sess = sess_cls.return_value
-        sess.exec_full_script.return_value = subprocess.CompletedProcess(
+        sess.exec_full_script_with_env.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="ok", stderr=""
         )
         ctx = ToolContext(context=None, tool_call_id="tf")
@@ -247,7 +247,7 @@ def test_execute_final_script() -> None:
         data = json.loads(result)
         assert data["success"] is True
         sess_cls.assert_called_once()
-        sess.exec_full_script.assert_called_once()
+        sess.exec_full_script_with_env.assert_called_once()
 
 
 def test_execute_final_script_windows_path() -> None:
@@ -263,7 +263,7 @@ def test_execute_final_script_windows_path() -> None:
         patch("circuitron.tools.os.listdir", return_value=["file.net"]),
     ):
         sess = sess_cls.return_value
-        sess.exec_full_script.return_value = subprocess.CompletedProcess(
+        sess.exec_full_script_with_env.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="ok", stderr=""
         )
         ctx = ToolContext(context=None, tool_call_id="tfw")
@@ -278,7 +278,7 @@ def test_execute_final_script_windows_path() -> None:
             f"circuitron-final-{os.getpid()}",
             volumes={"C:\\out": "/mnt/c/out"},
         )
-        sess.exec_full_script.assert_called_once()
+        sess.exec_full_script_with_env.assert_called_once()
 
 
 def test_prepare_runtime_check_script() -> None:


### PR DESCRIPTION
## Summary
- expose model dataclasses in pipeline exports
- adjust type hints and helpers in pipeline and utils
- update tests for new exec helper names and output_dir arguments
- ensure mocks cover exec_*_with_env methods

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fed5862e88333af42c32800c860d7