### PR TITLE
Implement PCB query guardrail and network checks

### DIFF
--- a/circuitron/agents.py
+++ b/circuitron/agents.py
@@ -48,6 +48,7 @@ from .tools import (
     get_kg_usage_guide,
 )
 from .mcp_manager import mcp_manager
+from .guardrails import pcb_query_guardrail
 
 
 def _tool_choice_for_mcp(model: str) -> str:
@@ -67,6 +68,7 @@ def create_planning_agent() -> Agent:
         model=settings.planning_model,
         output_type=PlanOutput,
         tools=tools,
+        input_guardrails=[pcb_query_guardrail],
         model_settings=model_settings,
     )
 

--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -5,6 +5,7 @@ from .config import setup_environment
 from .models import CodeGenerationOutput
 from circuitron.tools import kicad_session
 from .mcp_manager import mcp_manager
+from .network import check_internet_connection
 
 
 async def run_circuitron(
@@ -46,6 +47,9 @@ def main() -> None:
 
     args = parse_args()
     setup_environment(dev=args.dev)
+
+    if not check_internet_connection():
+        return
 
     if not verify_containers():
         return

--- a/circuitron/network.py
+++ b/circuitron/network.py
@@ -1,0 +1,24 @@
+"""Network utilities for Circuitron."""
+
+from __future__ import annotations
+
+import httpx
+
+
+def is_connected(url: str = "https://api.openai.com", timeout: float = 3.0) -> bool:
+    """Return ``True`` if ``url`` is reachable within ``timeout`` seconds."""
+    try:
+        httpx.head(url, timeout=timeout)
+        return True
+    except httpx.HTTPError:
+        return False
+
+
+def check_internet_connection() -> bool:
+    """Check for internet connectivity and print a message when absent."""
+    if not is_connected():
+        print("No internet connection detected. Please connect and try again.")
+        return False
+    return True
+
+__all__ = ["check_internet_connection", "is_connected"]

--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -18,6 +18,7 @@ from circuitron.config import settings
 from .mcp_manager import mcp_manager
 
 from circuitron.debug import run_agent
+from .network import check_internet_connection
 
 
 from circuitron.agents import (
@@ -654,6 +655,8 @@ async def main() -> None:
     from circuitron.config import setup_environment
 
     setup_environment(dev=args.dev)
+    if not check_internet_connection():
+        return
     await mcp_manager.initialize()
     try:
         prompt = args.prompt or input("Prompt: ")

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -139,7 +139,20 @@ def test_tool_choice_required_for_full_model() -> None:
     cfg.settings.documentation_model = "gpt-4o"
     cfg.settings.code_validation_model = "gpt-4o"
     cfg.settings.code_generation_model = "gpt-4o"
+    cfg.settings.code_correction_model = "gpt-4o"
     mod = importlib.import_module("circuitron.agents")
     assert mod.documentation.model_settings.tool_choice == "required"
     assert mod.code_validator.model_settings.tool_choice == "required"
     assert mod.code_corrector.model_settings.tool_choice == "required"
+
+
+def test_planner_has_pcb_guardrail() -> None:
+    import sys
+
+    sys.modules.pop("circuitron.agents", None)
+    import circuitron.config as cfg
+
+    cfg.setup_environment()
+    mod = importlib.import_module("circuitron.agents")
+    guard_names = [g.guardrail_function.__name__ for g in mod.planner.input_guardrails]
+    assert "pcb_query_guardrail" in guard_names

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,19 @@ def test_cli_main_no_prompt_on_container_failure(monkeypatch: pytest.MonkeyPatch
         run_mock.assert_not_called()
 
 
+def test_cli_main_checks_internet(monkeypatch: pytest.MonkeyPatch) -> None:
+    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None)
+    with patch("circuitron.cli.setup_environment"), \
+         patch("circuitron.pipeline.parse_args", return_value=args), \
+         patch("circuitron.cli.check_internet_connection", return_value=False), \
+         patch("circuitron.tools.kicad_session.start"), \
+         patch("circuitron.tools.kicad_session.stop") as stop_mock, \
+         patch("circuitron.cli.run_circuitron", AsyncMock()) as run_mock:
+        cli.main()
+        run_mock.assert_not_called()
+        stop_mock.assert_not_called()
+
+
 def test_cli_dev_mode_shows_run_items(capsys: pytest.CaptureFixture[str]) -> None:
     from circuitron import debug as dbg
     import circuitron.config as cfg

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,20 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import circuitron.debug as dbg
+
+
+def test_run_agent_handles_network_error(capsys: pytest.CaptureFixture[str]) -> None:
+    async def fake_run(*args, **kwargs):
+        import httpx
+
+        raise httpx.RequestError("fail")
+
+    with pytest.raises(RuntimeError):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(dbg.Runner, "run", fake_run)
+            asyncio.run(dbg.run_agent(SimpleNamespace(name="a"), "x"))
+    out = capsys.readouterr().out
+    assert "network error" in out.lower()

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -95,6 +95,12 @@ def test_pipeline_main(monkeypatch: pytest.MonkeyPatch) -> None:
     args = SimpleNamespace(prompt="p", reasoning=False, retries=1, dev=False, output_dir=None)
     monkeypatch.setattr(pl, "parse_args", lambda _=None: args)
     monkeypatch.setattr(pl, "run_with_retry", AsyncMock())
+    monkeypatch.setattr(pl, "check_internet_connection", lambda: False)
+    asyncio.run(pl.main())
+    cast(AsyncMock, pl.run_with_retry).assert_not_awaited()
+
+    # Now with connection available
+    monkeypatch.setattr(pl, "check_internet_connection", lambda: True)
     asyncio.run(pl.main())
     cast(AsyncMock, pl.run_with_retry).assert_awaited_with(
         "p",


### PR DESCRIPTION
## Summary
- introduce `pcb_query_guardrail` to refuse non-PCB requests with a cheap model
- check for internet connectivity in CLI and pipeline entry points
- handle network failures and guardrail tripwires inside `run_agent`
- add related unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68703610ee3c833381be8398c5082114