### PR TITLE
Improve docs for network and guardrail utilities

### DIFF
--- a/circuitron/guardrails.py
+++ b/circuitron/guardrails.py
@@ -26,7 +26,22 @@ pcb_query_agent = Agent(
 
 @input_guardrail
 async def pcb_query_guardrail(ctx, agent, input_data):
-    """Refuse processing if the user query is not PCB related."""
+    """Refuse processing if the user query is not PCB related.
+
+    Args:
+        ctx: The :class:`~agents.RunContextWrapper` supplied to the guardrail.
+        agent: The :class:`~agents.Agent` about to run.
+        input_data: The user's request or message payload.
+
+    Returns:
+        A :class:`GuardrailFunctionOutput` describing whether the query is
+        relevant. ``tripwire_triggered`` is ``True`` when the query is
+        unrelated to PCB design.
+
+    Example:
+        >>> await pcb_query_guardrail(ctx, agent, "Design a buck converter")
+        GuardrailFunctionOutput(...)
+    """
     result = await Runner.run(pcb_query_agent, input_data, context=ctx.context)
     output = result.final_output_as(PCBQueryOutput)
     return GuardrailFunctionOutput(output_info=output, tripwire_triggered=not output.is_relevant)

--- a/circuitron/network.py
+++ b/circuitron/network.py
@@ -6,7 +6,19 @@ import httpx
 
 
 def is_connected(url: str = "https://api.openai.com", timeout: float = 3.0) -> bool:
-    """Return ``True`` if ``url`` is reachable within ``timeout`` seconds."""
+    """Return ``True`` if ``url`` is reachable within ``timeout`` seconds.
+
+    Args:
+        url: Endpoint to send a ``HEAD`` request to.
+        timeout: Seconds to wait for the response.
+
+    Returns:
+        ``True`` when the endpoint responds without error, otherwise ``False``.
+
+    Example:
+        >>> is_connected()
+        True
+    """
     try:
         httpx.head(url, timeout=timeout)
         return True
@@ -15,7 +27,15 @@ def is_connected(url: str = "https://api.openai.com", timeout: float = 3.0) -> b
 
 
 def check_internet_connection() -> bool:
-    """Check for internet connectivity and print a message when absent."""
+    """Check for internet connectivity and print a message when absent.
+
+    Returns:
+        ``True`` if :func:`is_connected` succeeds, otherwise ``False``.
+
+    Example:
+        >>> check_internet_connection()
+        True
+    """
     if not is_connected():
         print("No internet connection detected. Please connect and try again.")
         return False


### PR DESCRIPTION
## Summary
- expand `is_connected` docstring with args, return and example
- describe `check_internet_connection` return type and add example
- document parameters and usage of `pcb_query_guardrail`

## Testing
- `ruff check .` *(fails: circuitron/docker_session.py:468 F841)*
- `mypy circuitron/network.py circuitron/guardrails.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870d856bfcc8333a0883002cdd9ae59