### PR TITLE
Handle network errors in PCB guardrail

### DIFF
--- a/circuitron/docker_session.py
+++ b/circuitron/docker_session.py
@@ -465,7 +465,7 @@ export KISYSMOD=/usr/share/kicad/modules
         
         for attempt in range(max_retries):
             try:
-                proc = self._run(cp_cmd, check=True)
+                self._run(cp_cmd, check=True)
                 return  # Success, exit the retry loop
             except subprocess.CalledProcessError as e:
                 error_msg = e.stderr.strip() if e.stderr else ""

--- a/circuitron/guardrails.py
+++ b/circuitron/guardrails.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel
 from agents import Agent, GuardrailFunctionOutput, Runner, input_guardrail
+import httpx
+import openai
 
 
 class PCBQueryOutput(BaseModel):
@@ -25,11 +29,19 @@ pcb_query_agent = Agent(
 
 
 @input_guardrail
-async def pcb_query_guardrail(ctx, agent, input_data):
+async def pcb_query_guardrail(ctx: Any, agent: Any, input_data: Any) -> GuardrailFunctionOutput:
     """Refuse processing if the user query is not PCB related."""
-    result = await Runner.run(pcb_query_agent, input_data, context=ctx.context)
+    try:
+        result = await Runner.run(pcb_query_agent, input_data, context=ctx.context)
+    except (httpx.HTTPError, openai.OpenAIError) as exc:
+        print(f"Network error: {exc}")
+        raise RuntimeError("Network connection issue") from exc
+
     output = result.final_output_as(PCBQueryOutput)
-    return GuardrailFunctionOutput(output_info=output, tripwire_triggered=not output.is_relevant)
+    return GuardrailFunctionOutput(
+        output_info=output,
+        tripwire_triggered=not output.is_relevant,
+    )
 
 
 __all__ = ["pcb_query_guardrail"]

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,20 +1,39 @@
 import asyncio
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 import circuitron.debug as dbg
+import circuitron.guardrails as gr
 
 
 def test_run_agent_handles_network_error(capsys: pytest.CaptureFixture[str]) -> None:
-    async def fake_run(*args, **kwargs):
+    async def fake_run(*args: Any, **kwargs: Any) -> None:
         import httpx
 
         raise httpx.RequestError("fail")
 
     with pytest.raises(RuntimeError):
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(dbg.Runner, "run", fake_run)
+            mp.setattr(dbg.Runner, "run", fake_run)  # type: ignore[attr-defined]
             asyncio.run(dbg.run_agent(SimpleNamespace(name="a"), "x"))
+    out = capsys.readouterr().out
+    assert "network error" in out.lower()
+
+
+def test_pcb_guardrail_handles_network_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_run(*args: Any, **kwargs: Any) -> None:
+        import httpx
+
+        raise httpx.RequestError("fail")
+
+    ctx = SimpleNamespace(context=None)
+    with pytest.raises(RuntimeError):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(dbg.Runner, "run", fake_run)  # type: ignore[attr-defined]
+            asyncio.run(gr.pcb_query_guardrail.guardrail_function(ctx, None, "x"))  # type: ignore[arg-type]
     out = capsys.readouterr().out
     assert "network error" in out.lower()


### PR DESCRIPTION
## Summary
- guardrail for PCB queries now catches network errors
- adjust docker cp helper to satisfy lint
- cover network error path for guardrail

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870d85940688333943edbfbf20b5652