### PR TITLE
Add guardrail tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,17 @@
 import os
+import sys
+from pathlib import Path
 from typing import Iterator
 
 import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 os.environ.setdefault("MCP_URL", "http://localhost:8051")
+
+# Ensure the project root is on sys.path for imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 @pytest.fixture(autouse=True)
 def _set_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,39 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+import circuitron.debug as dbg
+from circuitron.agents import planner
+from circuitron.guardrails import pcb_query_guardrail, PCBQueryOutput
+from agents.guardrail import GuardrailFunctionOutput
+
+
+def test_non_pcb_prompt_triggers_guardrail(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_guardrail = AsyncMock(
+        return_value=GuardrailFunctionOutput(
+            output_info=PCBQueryOutput(is_relevant=False, reasoning="no"),
+            tripwire_triggered=True,
+        )
+    )
+    monkeypatch.setattr(pcb_query_guardrail, "guardrail_function", mock_guardrail)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(dbg.run_agent(planner, "Tell me a joke"))
+
+    mock_guardrail.assert_awaited_once()
+    out = capsys.readouterr().out
+    assert "only assist" in out.lower()
+
+
+def test_guardrail_network_failure(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    async def raise_network(*_a, **_k):
+        import httpx
+
+        raise httpx.RequestError("fail")
+
+    monkeypatch.setattr(dbg.Runner, "run", raise_network)
+    with pytest.raises(RuntimeError):
+        asyncio.run(dbg.run_agent(planner, "design"))
+    out = capsys.readouterr().out
+    assert "network error" in out.lower()


### PR DESCRIPTION
## Summary
- ensure project root is in `sys.path` when running tests
- add tests that check pcb query guardrail behavior and network failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870d85ab1d08333b18ca32630616634