### PR TITLE
Improve pipeline network failure handling

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -6,6 +6,7 @@ from .models import CodeGenerationOutput
 from circuitron.tools import kicad_session
 from .mcp_manager import mcp_manager
 from .network import check_internet_connection
+from .exceptions import PipelineError
 
 
 async def run_circuitron(
@@ -20,12 +21,16 @@ async def run_circuitron(
 
     await mcp_manager.initialize()
     try:
-        return await run_with_retry(
-            prompt,
-            show_reasoning=show_reasoning,
-            retries=retries,
-            output_dir=output_dir,
-        )
+        try:
+            return await run_with_retry(
+                prompt,
+                show_reasoning=show_reasoning,
+                retries=retries,
+                output_dir=output_dir,
+            )
+        except PipelineError as exc:
+            print(f"Fatal error: {exc}")
+            return None
     finally:
         await mcp_manager.cleanup()
 

--- a/circuitron/exceptions.py
+++ b/circuitron/exceptions.py
@@ -1,0 +1,9 @@
+"""Custom exceptions for the Circuitron pipeline."""
+
+from __future__ import annotations
+
+
+class PipelineError(RuntimeError):
+    """Raised when the pipeline fails to complete due to a fatal error."""
+
+

--- a/circuitron/network.py
+++ b/circuitron/network.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import socket
 import httpx
 
 
@@ -22,7 +23,7 @@ def is_connected(url: str = "https://api.openai.com", timeout: float = 3.0) -> b
     try:
         httpx.head(url, timeout=timeout)
         return True
-    except httpx.HTTPError:
+    except (httpx.RequestError, socket.gaierror, TimeoutError, OSError):
         return False
 
 

--- a/circuitron/settings.py
+++ b/circuitron/settings.py
@@ -39,4 +39,7 @@ class Settings:
     max_turns: int = field(
         default_factory=lambda: int(os.getenv("CIRCUITRON_MAX_TURNS", "50"))
     )
+    network_timeout: float = field(
+        default_factory=lambda: float(os.getenv("CIRCUITRON_NETWORK_TIMEOUT", "60"))
+    )
     dev_mode: bool = False

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -6,6 +6,7 @@ import pytest
 import circuitron.debug as dbg
 from circuitron.agents import planner
 from circuitron.guardrails import pcb_query_guardrail, PCBQueryOutput
+from circuitron.exceptions import PipelineError
 from agents.guardrail import GuardrailFunctionOutput
 
 
@@ -18,7 +19,7 @@ def test_non_pcb_prompt_triggers_guardrail(capsys: pytest.CaptureFixture[str], m
     )
     monkeypatch.setattr(pcb_query_guardrail, "guardrail_function", mock_guardrail)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(PipelineError):
         asyncio.run(dbg.run_agent(planner, "Tell me a joke"))
 
     mock_guardrail.assert_awaited_once()
@@ -33,7 +34,7 @@ def test_guardrail_network_failure(capsys: pytest.CaptureFixture[str], monkeypat
         raise httpx.RequestError("fail")
 
     monkeypatch.setattr(dbg.Runner, "run", raise_network)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(PipelineError):
         asyncio.run(dbg.run_agent(planner, "design"))
     out = capsys.readouterr().out
     assert "network error" in out.lower()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,11 +1,14 @@
 import asyncio
 from types import SimpleNamespace
 from typing import Any
+import socket
 
 import pytest
 
 import circuitron.debug as dbg
 import circuitron.guardrails as gr
+import circuitron.network as net
+from circuitron.exceptions import PipelineError
 
 
 def test_run_agent_handles_network_error(capsys: pytest.CaptureFixture[str]) -> None:
@@ -14,7 +17,7 @@ def test_run_agent_handles_network_error(capsys: pytest.CaptureFixture[str]) -> 
 
         raise httpx.RequestError("fail")
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(PipelineError):
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(dbg.Runner, "run", fake_run)  # type: ignore[attr-defined]
             asyncio.run(dbg.run_agent(SimpleNamespace(name="a"), "x"))
@@ -31,9 +34,25 @@ def test_pcb_guardrail_handles_network_error(
         raise httpx.RequestError("fail")
 
     ctx = SimpleNamespace(context=None)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(PipelineError):
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(dbg.Runner, "run", fake_run)  # type: ignore[attr-defined]
             asyncio.run(gr.pcb_query_guardrail.guardrail_function(ctx, None, "x"))  # type: ignore[arg-type]
     out = capsys.readouterr().out
     assert "network error" in out.lower()
+
+
+def test_is_connected_handles_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        net.httpx,
+        "head",
+        lambda *_a, **_k: (_ for _ in ()).throw(net.httpx.RequestError("fail")),
+    )
+    assert net.is_connected() is False
+
+    def raise_gai(*_a: Any, **_k: Any) -> None:
+        raise socket.gaierror
+
+    monkeypatch.setattr(net.httpx, "head", raise_gai)
+    assert net.is_connected() is False
+

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -399,9 +399,21 @@ async def fake_run_with_retry_fail() -> None:
         assert result is None
 
 
+async def fake_run_with_retry_network_error() -> None:
+    from circuitron import pipeline as pl
+
+    async def fail_network(*args: object, **kwargs: object) -> None:
+        raise pl.PipelineError("net")
+
+    with patch.object(pl, "pipeline", AsyncMock(side_effect=fail_network)):
+        with pytest.raises(pl.PipelineError):
+            await pl.run_with_retry("p", retries=2)
+
+
 def test_run_with_retry_behaviour() -> None:
     asyncio.run(fake_run_with_retry_success())
     asyncio.run(fake_run_with_retry_fail())
+    asyncio.run(fake_run_with_retry_network_error())
 
 
 async def fake_pipeline_validation_error() -> None:


### PR DESCRIPTION
## Summary
- broaden exception handling in `is_connected`
- add `PipelineError` exception class
- check connectivity and add timeouts in agent/guardrail wrappers
- surface `PipelineError` up to `run_with_retry` and CLI entry points
- track network timeout in settings
- test new behavior

## Testing
- `ruff check .`
- `mypy --strict circuitron`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e2731c0c833384e633ff8c0449cd