### PR TITLE
feat: automated onboarding and mcp management

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -1,12 +1,43 @@
 """Command line interface for Circuitron."""
 
+import argparse
 import asyncio
 from .config import setup_environment
 from .models import CodeGenerationOutput
 from circuitron.tools import kicad_session
+from .mcp_server import ensure_running as ensure_mcp
 from .mcp_manager import mcp_manager
 from .network import check_internet_connection
 from .exceptions import PipelineError
+from .onboarding import run_onboarding
+
+
+def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the Circuitron CLI."""
+    parser = argparse.ArgumentParser(description="Circuitron CLI")
+    sub = parser.add_subparsers(dest="command")
+
+    run_parser = sub.add_parser("run", help="execute pipeline")
+    run_parser.add_argument("prompt", nargs="?", help="Design prompt")
+    run_parser.add_argument("-r", "--reasoning", action="store_true", help="show reasoning summary")
+    run_parser.add_argument("--dev", action="store_true", help="enable tracing with logfire")
+    run_parser.add_argument("-n", "--retries", type=int, default=0, help="number of retries")
+    run_parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=str,
+        default=None,
+        help="directory to save generated files (default: ./circuitron_output)",
+    )
+
+    sub.add_parser("config", help="update stored credentials")
+    sub.add_parser("status", help="show service status")
+
+    args = parser.parse_args(argv)
+    if args.command is None:
+        # default to run when no subcommand is provided
+        args = parser.parse_args(["run"] + (argv or []))
+    return args
 
 
 async def run_circuitron(
@@ -40,6 +71,9 @@ def verify_containers() -> bool:
 
     try:
         kicad_session.start()
+        if not ensure_mcp():
+            print("Failed to start MCP server container")
+            return False
     except Exception as exc:
         print(f"Failed to start KiCad container: {exc}")
         return False
@@ -48,9 +82,19 @@ def verify_containers() -> bool:
 
 def main() -> None:
     """Main entry point for the Circuitron system."""
-    from circuitron.pipeline import parse_args
 
-    args = parse_args()
+    args = parse_cli_args()
+
+    if args.command == "config":
+        run_onboarding()
+        return
+
+    if args.command == "status":
+        setup_environment()
+        ok = ensure_mcp()
+        print(f"MCP server running: {ok}")
+        return
+
     setup_environment(dev=args.dev)
 
     if not check_internet_connection():

--- a/circuitron/mcp_server.py
+++ b/circuitron/mcp_server.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+"""Utilities to manage the MCP server Docker container."""
+
+import atexit
+import logging
+import os
+import subprocess
+import time
+import urllib.request
+from typing import Any
+
+CONTAINER_NAME = "circuitron-mcp"
+IMAGE = "ghcr.io/shaurya-sethi/sentinel-mcp:latest"
+
+
+def _run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+
+
+def _health_check(url: str) -> bool:
+    try:
+        with urllib.request.urlopen(f"{url}/health", timeout=5):
+            pass
+        return True
+    except Exception:
+        return False
+
+
+def is_running(url: str) -> bool:
+    return _health_check(url)
+
+
+def _container_status() -> str | None:
+    proc = _run(
+        ["docker", "ps", "-a", "--filter", f"name={CONTAINER_NAME}", "--format", "{{.Status}}"],
+    )
+    if proc.returncode != 0:
+        logging.warning("docker ps failed: %s", proc.stderr.strip())
+        return None
+    return proc.stdout.strip() or None
+
+
+def _remove_container() -> None:
+    _run(["docker", "rm", "-f", CONTAINER_NAME])
+
+
+def start() -> bool:
+    """Start the MCP Docker container if it is not running."""
+    url = os.getenv("MCP_URL", "http://localhost:8051")
+    if is_running(url):
+        return True
+
+    status = _container_status()
+    if status:
+        if status.lower().startswith("up"):
+            if is_running(url):
+                return True
+        _remove_container()
+
+    env_vars = {
+        k: os.getenv(k, v)
+        for k, v in {
+            "OPENAI_API_KEY": "",
+            "SUPABASE_URL": "",
+            "SUPABASE_SERVICE_KEY": "",
+            "NEO4J_URI": "",
+            "NEO4J_USER": "",
+            "NEO4J_PASSWORD": "",
+            "HOST": "0.0.0.0",
+            "PORT": "8051",
+            "TRANSPORT": "sse",
+            "MODEL_CHOICE": "gpt-4.1-nano",
+            "USE_CONTEXTUAL_EMBEDDINGS": "true",
+            "USE_HYBRID_SEARCH": "true",
+            "USE_AGENTIC_RAG": "true",
+            "USE_RERANKING": "true",
+            "USE_KNOWLEDGE_GRAPH": "true",
+            "LLM_MAX_CONCURRENCY": "2",
+            "LLM_REQUEST_DELAY": "0.5",
+        }.items()
+    }
+
+    cmd = [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        CONTAINER_NAME,
+        "-p",
+        f"{os.getenv('PORT', '8051')}:8051",
+    ]
+    for k, v in env_vars.items():
+        if v:
+            cmd.extend(["-e", f"{k}={v}"])
+    cmd.append(IMAGE)
+
+    proc = _run(cmd)
+    if proc.returncode != 0:
+        logging.error("Failed to start MCP container: %s", proc.stderr.strip())
+        return False
+
+    for _ in range(20):
+        time.sleep(1)
+        if is_running(url):
+            atexit.register(stop)
+            return True
+    logging.error("MCP server failed to start")
+    return False
+
+
+def stop() -> None:
+    """Stop the MCP Docker container."""
+    _remove_container()
+
+
+def ensure_running() -> bool:
+    """Ensure the MCP server is available."""
+    url = os.getenv("MCP_URL", "http://localhost:8051")
+    if is_running(url):
+        return True
+    return start()
+
+
+__all__ = ["ensure_running", "start", "stop", "is_running"]

--- a/circuitron/onboarding.py
+++ b/circuitron/onboarding.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Interactive onboarding for Circuitron configuration."""
+
+import os
+from pathlib import Path
+
+import click
+from dotenv import dotenv_values, set_key
+
+
+ENV_DIR = Path.home() / ".circuitron"
+ENV_FILE = ENV_DIR / ".env"
+
+# (prompt text, hide_input)
+REQUIRED_VARS: list[tuple[str, str, bool]] = [
+    ("OPENAI_API_KEY", "OpenAI API key", True),
+    ("SUPABASE_URL", "Supabase URL", False),
+    ("SUPABASE_SERVICE_KEY", "Supabase service key", True),
+    ("NEO4J_URI", "Neo4j URI", False),
+    ("NEO4J_USER", "Neo4j username", False),
+    ("NEO4J_PASSWORD", "Neo4j password", True),
+]
+
+PRESET_VARS = {
+    "HOST": "0.0.0.0",
+    "PORT": "8051",
+    "TRANSPORT": "sse",
+    "MODEL_CHOICE": "gpt-4.1-nano",
+    "USE_CONTEXTUAL_EMBEDDINGS": "true",
+    "USE_HYBRID_SEARCH": "true",
+    "USE_AGENTIC_RAG": "true",
+    "USE_RERANKING": "true",
+    "USE_KNOWLEDGE_GRAPH": "true",
+    "LLM_MAX_CONCURRENCY": "2",
+    "LLM_REQUEST_DELAY": "0.5",
+    "MCP_URL": "http://localhost:8051",
+    "KICAD_IMAGE": "ghcr.io/shaurya-sethi/circuitron-kicad:latest",
+}
+
+
+def run_onboarding() -> None:
+    """Collect credentials interactively and save them to ``ENV_FILE``."""
+
+    click.echo()
+    click.secho("Circuitron setup", fg="cyan", bold=True)
+    click.echo("Provide the following credentials. Press Enter to keep existing values.\n")
+
+    ENV_DIR.mkdir(parents=True, exist_ok=True)
+    existing = dotenv_values(dotenv_path=ENV_FILE)
+
+    def ask(var: str, prompt: str, hide: bool) -> str:
+        default = existing.get(var, "")
+        return click.prompt(
+            prompt,
+            default=default,
+            hide_input=hide,
+            show_default=bool(default),
+            type=str,
+        )
+
+    creds = {}
+    for var, prompt, hide in REQUIRED_VARS:
+        creds[var] = ask(var, prompt, hide)
+
+    creds.update(PRESET_VARS)
+
+    for key, val in creds.items():
+        set_key(str(ENV_FILE), key, val)
+
+    click.echo(f"\nConfiguration saved to {ENV_FILE}\n")
+
+__all__ = ["run_onboarding", "ENV_FILE"]

--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -652,9 +652,12 @@ async def main() -> None:
     """CLI entry point for the Circuitron pipeline."""
     args = parse_args()
     from circuitron.config import setup_environment
+    from circuitron.cli import verify_containers
 
     setup_environment(dev=args.dev)
     if not check_internet_connection():
+        return
+    if not verify_containers():
         return
     await mcp_manager.initialize()
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,13 @@ import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 os.environ.setdefault("MCP_URL", "http://localhost:8051")
+os.environ.setdefault("SUPABASE_URL", "http://supabase")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "svc")
+os.environ.setdefault("NEO4J_URI", "bolt://neo4j")
+os.environ.setdefault("NEO4J_USER", "neo")
+os.environ.setdefault("NEO4J_PASSWORD", "pass")
+os.environ.setdefault("CIRCUITRON_AUTO_ONBOARD", "0")
+os.environ.setdefault("CIRCUITRON_ENV_FILE", "/tmp/circuitron_test.env")
 
 # Ensure the project root is on sys.path for imports
 ROOT = Path(__file__).resolve().parents[1]
@@ -17,5 +24,12 @@ if str(ROOT) not in sys.path:
 def _set_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setenv("MCP_URL", "http://localhost:8051")
+    monkeypatch.setenv("SUPABASE_URL", "http://supabase")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "svc")
+    monkeypatch.setenv("NEO4J_URI", "bolt://neo4j")
+    monkeypatch.setenv("NEO4J_USER", "neo")
+    monkeypatch.setenv("NEO4J_PASSWORD", "pass")
+    monkeypatch.setenv("CIRCUITRON_AUTO_ONBOARD", "0")
+    monkeypatch.setenv("CIRCUITRON_ENV_FILE", "/tmp/circuitron_test.env")
     yield
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,16 +1,33 @@
+import os
 import pytest
 
 import circuitron.config as cfg
 
 
-def test_setup_environment_requires_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_setup_environment_triggers_onboarding(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("MCP_URL", raising=False)
-    with pytest.raises(SystemExit) as exc:
-        cfg.setup_environment()
-    message = str(exc.value)
-    for var in ["OPENAI_API_KEY", "MCP_URL"]:
-        assert var in message
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    called = False
+
+    def fake_onboard() -> None:
+        nonlocal called
+        called = True
+        os.environ.update(
+            {
+                "OPENAI_API_KEY": "k",
+                "SUPABASE_URL": "u",
+                "SUPABASE_SERVICE_KEY": "s",
+                "NEO4J_URI": "n",
+                "NEO4J_USER": "u",
+                "NEO4J_PASSWORD": "p",
+                "MCP_URL": "http://m",
+            }
+        )
+
+    monkeypatch.setattr(cfg, "run_onboarding", fake_onboard)
+    monkeypatch.setenv("CIRCUITRON_AUTO_ONBOARD", "1")
+    cfg.setup_environment()
+    assert called
 
 
 def test_settings_updated_in_place(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,23 @@
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import circuitron.mcp_server as srv
+
+
+def test_ensure_running_starts_container(monkeypatch):
+    state = {"running": False}
+
+    def fake_is_running(_url: str) -> bool:
+        return state["running"]
+
+    def fake_run(cmd, **kwargs):
+        if "run" in cmd:
+            state["running"] = True
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(srv, "is_running", fake_is_running)
+    monkeypatch.setattr(srv, "_run", fake_run)
+    monkeypatch.setattr(srv.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(srv.atexit, "register", lambda *_a, **_k: None)
+    assert srv.ensure_running() is True

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,21 @@
+import os
+from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import patch
+
+import circuitron.onboarding as ob
+
+
+def test_run_onboarding_writes_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    env_path = Path(tmp_path, ".circuitron", ".env")
+    monkeypatch.setattr(ob, "ENV_FILE", env_path)
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    inputs = iter(["k", "surl", "skey", "uri", "user", "pass"])
+    monkeypatch.setattr(ob.click, "prompt", lambda *_a, **_k: next(inputs))
+    ob.run_onboarding()
+    env = Path(tmp_path, ".circuitron", ".env")
+    data = env.read_text()
+    assert "OPENAI_API_KEY='k'" in data
+    assert "SUPABASE_URL='surl'" in data
+    assert "NEO4J_USER='user'" in data

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -96,11 +96,13 @@ def test_pipeline_main(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pl, "parse_args", lambda _=None: args)
     monkeypatch.setattr(pl, "run_with_retry", AsyncMock())
     monkeypatch.setattr(pl, "check_internet_connection", lambda: False)
+    monkeypatch.setattr("circuitron.cli.verify_containers", lambda: True)
     asyncio.run(pl.main())
     cast(AsyncMock, pl.run_with_retry).assert_not_awaited()
 
     # Now with connection available
     monkeypatch.setattr(pl, "check_internet_connection", lambda: True)
+    monkeypatch.setattr("circuitron.cli.verify_containers", lambda: True)
     asyncio.run(pl.main())
     cast(AsyncMock, pl.run_with_retry).assert_awaited_with(
         "p",


### PR DESCRIPTION
## Summary
- add interactive onboarding to capture credentials
- load credentials from `~/.circuitron/.env` in config
- manage MCP server Docker container automatically
- enhance CLI with config and status commands
- ensure containers are started before running workflows
- update tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870ebefb88483339d1256825f638b70