### PR TITLE
Fix MCP port mapping

### DIFF
--- a/circuitron/mcp_server.py
+++ b/circuitron/mcp_server.py
@@ -81,6 +81,7 @@ def start() -> bool:
         }.items()
     }
 
+    host_port = os.getenv("MCP_PORT", "8051")
     cmd = [
         "docker",
         "run",
@@ -88,7 +89,7 @@ def start() -> bool:
         "--name",
         CONTAINER_NAME,
         "-p",
-        f"{os.getenv('PORT', '8051')}:8051",
+        f"{host_port}:8051",
     ]
     for k, v in env_vars.items():
         if v:

--- a/circuitron/onboarding.py
+++ b/circuitron/onboarding.py
@@ -25,6 +25,7 @@ REQUIRED_VARS: list[tuple[str, str, bool]] = [
 PRESET_VARS = {
     "HOST": "0.0.0.0",
     "PORT": "8051",
+    "MCP_PORT": "8051",
     "TRANSPORT": "sse",
     "MODEL_CHOICE": "gpt-4.1-nano",
     "USE_CONTEXTUAL_EMBEDDINGS": "true",

--- a/onboard.txt
+++ b/onboard.txt
@@ -1,0 +1,2 @@
+The MCP server container exposes port 8051. Circuitron maps this port to the host using the ``MCP_PORT`` environment variable, defaulting to ``8051``. The ``PORT`` variable is still passed into the container but no longer affects host port mapping.
+

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7,11 +7,13 @@ import circuitron.mcp_server as srv
 
 def test_ensure_running_starts_container(monkeypatch):
     state = {"running": False}
+    commands: list[list[str]] = []
 
     def fake_is_running(_url: str) -> bool:
         return state["running"]
 
     def fake_run(cmd, **kwargs):
+        commands.append(cmd)
         if "run" in cmd:
             state["running"] = True
         return subprocess.CompletedProcess(cmd, 0, "", "")
@@ -20,4 +22,36 @@ def test_ensure_running_starts_container(monkeypatch):
     monkeypatch.setattr(srv, "_run", fake_run)
     monkeypatch.setattr(srv.time, "sleep", lambda *_: None)
     monkeypatch.setattr(srv.atexit, "register", lambda *_a, **_k: None)
+    monkeypatch.setenv("PORT", "9999")
+    monkeypatch.delenv("MCP_PORT", raising=False)
     assert srv.ensure_running() is True
+    run_cmd = commands[-1]
+    idx = run_cmd.index("-p")
+    assert run_cmd[idx + 1] == "8051:8051"
+    assert f"PORT=9999" in run_cmd
+
+
+def test_mcp_port_env_var_overrides_host_mapping(monkeypatch):
+    state = {"running": False}
+    commands: list[list[str]] = []
+
+    def fake_is_running(_url: str) -> bool:
+        return state["running"]
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        if "run" in cmd:
+            state["running"] = True
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(srv, "is_running", fake_is_running)
+    monkeypatch.setattr(srv, "_run", fake_run)
+    monkeypatch.setattr(srv.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(srv.atexit, "register", lambda *_a, **_k: None)
+    monkeypatch.setenv("MCP_PORT", "1234")
+    monkeypatch.setenv("PORT", "9999")
+    assert srv.ensure_running() is True
+    run_cmd = commands[-1]
+    idx = run_cmd.index("-p")
+    assert run_cmd[idx + 1] == "1234:8051"
+    assert f"PORT=9999" in run_cmd

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -19,3 +19,4 @@ def test_run_onboarding_writes_env(tmp_path, monkeypatch):
     assert "OPENAI_API_KEY='k'" in data
     assert "SUPABASE_URL='surl'" in data
     assert "NEO4J_USER='user'" in data
+    assert "MCP_PORT='8051'" in data


### PR DESCRIPTION
## Summary
- use MCP_PORT env var for host port binding
- check port mapping logic in tests
- include MCP_PORT default in onboarding
- document the new variable in onboard.txt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68716425190c8333b15f09ad4dc27264