### PR TITLE
Fix container port mapping

### DIFF
--- a/circuitron/mcp_server.py
+++ b/circuitron/mcp_server.py
@@ -81,7 +81,6 @@ def start() -> bool:
         }.items()
     }
 
-    host_port = os.getenv("MCP_PORT", "8051")
     cmd = [
         "docker",
         "run",
@@ -89,7 +88,7 @@ def start() -> bool:
         "--name",
         CONTAINER_NAME,
         "-p",
-        f"{host_port}:8051",
+        "8051:8051",
     ]
     for k, v in env_vars.items():
         if v:

--- a/circuitron/onboarding.py
+++ b/circuitron/onboarding.py
@@ -25,7 +25,6 @@ REQUIRED_VARS: list[tuple[str, str, bool]] = [
 PRESET_VARS = {
     "HOST": "0.0.0.0",
     "PORT": "8051",
-    "MCP_PORT": "8051",
     "TRANSPORT": "sse",
     "MODEL_CHOICE": "gpt-4.1-nano",
     "USE_CONTEXTUAL_EMBEDDINGS": "true",

--- a/onboard.txt
+++ b/onboard.txt
@@ -1,0 +1,2 @@
+The MCP server always exposes port `8051` inside its Docker container and maps it
+to port `8051` on the host. The port mapping cannot be changed.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,6 +1,4 @@
 import subprocess
-from types import SimpleNamespace
-from unittest.mock import patch
 
 import circuitron.mcp_server as srv
 
@@ -23,35 +21,8 @@ def test_ensure_running_starts_container(monkeypatch):
     monkeypatch.setattr(srv.time, "sleep", lambda *_: None)
     monkeypatch.setattr(srv.atexit, "register", lambda *_a, **_k: None)
     monkeypatch.setenv("PORT", "9999")
-    monkeypatch.delenv("MCP_PORT", raising=False)
     assert srv.ensure_running() is True
     run_cmd = commands[-1]
     idx = run_cmd.index("-p")
     assert run_cmd[idx + 1] == "8051:8051"
-    assert f"PORT=9999" in run_cmd
-
-
-def test_mcp_port_env_var_overrides_host_mapping(monkeypatch):
-    state = {"running": False}
-    commands: list[list[str]] = []
-
-    def fake_is_running(_url: str) -> bool:
-        return state["running"]
-
-    def fake_run(cmd, **kwargs):
-        commands.append(cmd)
-        if "run" in cmd:
-            state["running"] = True
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    monkeypatch.setattr(srv, "is_running", fake_is_running)
-    monkeypatch.setattr(srv, "_run", fake_run)
-    monkeypatch.setattr(srv.time, "sleep", lambda *_: None)
-    monkeypatch.setattr(srv.atexit, "register", lambda *_a, **_k: None)
-    monkeypatch.setenv("MCP_PORT", "1234")
-    monkeypatch.setenv("PORT", "9999")
-    assert srv.ensure_running() is True
-    run_cmd = commands[-1]
-    idx = run_cmd.index("-p")
-    assert run_cmd[idx + 1] == "1234:8051"
     assert f"PORT=9999" in run_cmd

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -19,4 +19,3 @@ def test_run_onboarding_writes_env(tmp_path, monkeypatch):
     assert "OPENAI_API_KEY='k'" in data
     assert "SUPABASE_URL='surl'" in data
     assert "NEO4J_USER='user'" in data
-    assert "MCP_PORT='8051'" in data


### PR DESCRIPTION
## Summary
- simplify port mapping for mcp server
- update onboarding defaults and docs
- remove obsolete MCP_PORT test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68716b7500e48333951223904de2cbbd