### PR TITLE
Fix server health check endpoint

### DIFF
--- a/circuitron/config.py
+++ b/circuitron/config.py
@@ -32,8 +32,6 @@ def _check_mcp_health(url: str) -> None:
     if os.getenv("MCP_HEALTHCHECK") not in {"1", "true", "yes"}:
         return
     try:
-        with urllib.request.urlopen(f"{url}/health", timeout=5):
-            pass
         with urllib.request.urlopen(f"{url}/sse", timeout=5):
             pass
     except Exception as exc:  # pragma: no cover - network errors

--- a/circuitron/mcp_server.py
+++ b/circuitron/mcp_server.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utilities to manage the MCP server Docker container."""
+
+from __future__ import annotations
 
 import atexit
 import logging
@@ -19,8 +19,9 @@ def _run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
 
 
 def _health_check(url: str) -> bool:
+    """Check if the MCP server is reachable via its SSE endpoint."""
     try:
-        with urllib.request.urlopen(f"{url}/health", timeout=5):
+        with urllib.request.urlopen(f"{url}/sse", timeout=5):
             pass
         return True
     except Exception:


### PR DESCRIPTION
## Summary
- update MCP health check to look for `/sse` instead of the missing `/health` endpoint
- fix lint errors in `mcp_server.py` by reordering docstring and imports

## Testing
- `ruff check circuitron/mcp_server.py circuitron/config.py`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687174faf2a083338e510b46426e5601