### PR TITLE
Adjust MCP server startup wait

### DIFF
--- a/circuitron/mcp_server.py
+++ b/circuitron/mcp_server.py
@@ -34,7 +34,15 @@ def is_running(url: str) -> bool:
 
 def _container_status() -> str | None:
     proc = _run(
-        ["docker", "ps", "-a", "--filter", f"name={CONTAINER_NAME}", "--format", "{{.Status}}"],
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            f"name={CONTAINER_NAME}",
+            "--format",
+            "{{.Status}}",
+        ],
     )
     if proc.returncode != 0:
         logging.warning("docker ps failed: %s", proc.stderr.strip())
@@ -101,12 +109,13 @@ def start() -> bool:
         logging.error("Failed to start MCP container: %s", proc.stderr.strip())
         return False
 
-    for _ in range(20):
+    max_attempts = int(os.getenv("MCP_START_MAX_ATTEMPTS", "20"))
+    for _ in range(max_attempts):
         time.sleep(1)
         if is_running(url):
             atexit.register(stop)
             return True
-    logging.error("MCP server failed to start")
+    logging.error("MCP server failed to start after %s seconds", max_attempts)
     return False
 
 


### PR DESCRIPTION
## Summary
- allow configuring MCP startup wait time via `MCP_START_MAX_ATTEMPTS`
- ensure `start()` uses the env var and logs how long it waited
- test that the new env var is respected

## Testing
- `ruff check circuitron/mcp_server.py tests/test_mcp_server.py`
- `mypy circuitron/mcp_server.py tests/test_mcp_server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68717bc8c14c83338226b9404e3c740a