### PR TITLE
Improve Terminal UI with theming and rich prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ circuitron --dev "Design a voltage divider"
 ```
 
 The `--output-dir` option saves all generated files to a specific location. By default results are written to `./circuitron_output`.
+
+### Theme Switching
+
+Use the `/theme` command at any prompt to switch between `electric`, `dark`, and `light` themes. The chosen theme is stored in `~/.circuitron`.
 ### Running Tests
 
 ```bash

--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -60,7 +60,9 @@ def main() -> None:
     if not verify_containers():
         return
 
-    prompt = args.prompt or input("Prompt: ")
+    ui = TerminalUI()
+    ui.start_banner()
+    prompt = args.prompt or ui.prompt_user("Prompt")
     show_reasoning = args.reasoning
     retries = args.retries
     output_dir = args.output_dir
@@ -68,7 +70,6 @@ def main() -> None:
     code_output: CodeGenerationOutput | None = None
     try:
         try:
-            ui = TerminalUI()
             code_output = asyncio.run(
                 ui.run(prompt, show_reasoning=show_reasoning, retries=retries, output_dir=output_dir)
             )

--- a/circuitron/ui/app.py
+++ b/circuitron/ui/app.py
@@ -1,31 +1,47 @@
-from __future__ import annotations
+"""Terminal UI implementation using Rich and prompt_toolkit."""
 
 from typing import Iterable
+from pathlib import Path
 
 from rich.console import Console
 from rich.text import Text
+from rich.panel import Panel
+from rich.markdown import Markdown
+import sys
+
+from prompt_toolkit import PromptSession  # type: ignore
+from prompt_toolkit.history import FileHistory  # type: ignore
 
 from circuitron.logo import LOGO_ART, apply_gradient
-from .themes import ELECTRIC_THEME, Theme
+from .themes import Theme, theme_manager
 from .components.progress import StageSpinner
 from .. import utils
 from ..models import PlanOutput
 
 
 class TerminalUI:
-    """Simple interactive terminal UI using Rich."""
+    """Interactive terminal UI using Rich and prompt_toolkit."""
 
     def __init__(self, console: Console | None = None, theme: Theme | None = None) -> None:
         self.console = console or Console()
-        self.theme = theme or ELECTRIC_THEME
+        self.theme = theme or theme_manager.get_theme()
         self.spinner = StageSpinner(self.console)
+        history_file = Path.home() / ".circuitron_history"
+        self.session: PromptSession = PromptSession(
+            history=FileHistory(str(history_file))
+        )
 
     def start_banner(self) -> None:
         """Render the Circuitron banner with gradient colors."""
         logo_text = Text.from_ansi(LOGO_ART)
         gradient_logo = apply_gradient(logo_text, self.theme.gradient_colors)
         self.console.print(gradient_logo, justify="center")
-        self.console.print()
+        self.console.print("[bold]Type /help for commands[/bold]\n")
+
+    def set_theme(self, name: str) -> None:
+        """Switch to a new theme."""
+        theme_manager.set_theme(name)
+        self.theme = theme_manager.get_theme()
 
     def start_stage(self, name: str) -> None:
         self.spinner.start(name)
@@ -33,17 +49,36 @@ class TerminalUI:
     def finish_stage(self, name: str) -> None:
         self.spinner.stop(name)
 
+    def prompt_user(self, message: str) -> str:
+        """Prompt the user for input using prompt_toolkit."""
+        while True:
+            if not sys.stdin.isatty():
+                text = input(f"{message}: ")
+            else:
+                text = self.session.prompt(f"{message}: ")
+            if text.strip() == "/help":
+                self.console.print("Available commands: /theme <name>, /help")
+                continue
+            if text.startswith("/theme"):
+                parts = text.split()
+                if len(parts) == 2 and parts[1] in theme_manager.available_themes():
+                    self.set_theme(parts[1])
+                    self.console.print(f"Theme switched to {parts[1]}")
+                else:
+                    self.console.print(f"Available themes: {', '.join(theme_manager.available_themes())}")
+                continue
+            return text
+
     def display_plan(self, plan: PlanOutput) -> None:
         """Pretty print the generated plan."""
-        utils.pretty_print_plan(plan)
+        utils.pretty_print_plan(plan, console=self.console)
 
     def collect_feedback(self, plan: PlanOutput) -> utils.UserFeedback:
-        return utils.collect_user_feedback(plan)
+        return utils.collect_user_feedback(plan, input_func=self.prompt_user)
 
     def display_files(self, files: Iterable[str]) -> None:
-        self.console.print("\n=== GENERATED FILES ===")
-        for path in files:
-            self.console.print(f"[link=file://{path}]{path}[/]")
+        links = "\n".join(f"[link=file://{p}]{p}[/]" for p in files)
+        self.console.print(Panel(Markdown(links), title="Generated Files", expand=False))
 
     async def run(
         self,
@@ -55,7 +90,6 @@ class TerminalUI:
         """Execute the Circuitron pipeline with UI feedback."""
         from ..pipeline import run_with_retry
 
-        self.start_banner()
         return await run_with_retry(
             prompt,
             show_reasoning=show_reasoning,

--- a/circuitron/ui/components/progress.py
+++ b/circuitron/ui/components/progress.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from rich.console import Console
 from rich.status import Status
+from time import perf_counter
 
 
 class StageSpinner:
@@ -10,15 +11,18 @@ class StageSpinner:
     def __init__(self, console: Console) -> None:
         self.console = console
         self.status: Status | None = None
+        self.start_time = 0.0
 
     def start(self, stage: str) -> None:
         """Begin a spinner for ``stage``."""
+        self.start_time = perf_counter()
         self.status = self.console.status(f"[bold cyan]{stage}...", spinner="dots")
         self.status.start()
 
     def stop(self, stage: str) -> None:
         """Stop the spinner and mark ``stage`` complete."""
         if self.status:
-            self.status.update(f"[green]{stage} complete")
+            elapsed = perf_counter() - self.start_time
+            self.status.update(f"[green]{stage} complete ({elapsed:.1f}s)")
             self.status.stop()
             self.status = None

--- a/circuitron/ui/themes.py
+++ b/circuitron/ui/themes.py
@@ -1,24 +1,79 @@
+"""Theme definitions and manager for Circuitron's terminal UI."""
+
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import List
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import json
+import os
 
 import circuitron.logo as logo
 
 @dataclass
 class Theme:
-    """Simple color theme with gradient colors."""
+    """Color theme definition."""
 
     name: str
     gradient_colors: List[str]
     accent: str = "cyan"
 
 
-def get_theme(name: str) -> Theme:
-    """Return a theme by name."""
-    colors = logo.THEMES.get(name)
-    if not colors:
-        raise ValueError(f"Unknown theme: {name}")
-    return Theme(name=name, gradient_colors=colors)
+class ThemeManager:
+    """Manage available themes and the active selection."""
 
+    CONFIG_FILE = Path.home() / ".circuitron"
+
+    def __init__(self) -> None:
+        self.themes: Dict[str, Theme] = {
+            name: Theme(name=name, gradient_colors=colors)
+            for name, colors in logo.THEMES.items()
+        }
+        # Built-in additional themes
+        self.themes.update(
+            {
+                "dark": Theme("dark", ["#1E1E2E", "#89B4FA", "#CBA6F7"]),
+                "light": Theme("light", ["#FFFFFF", "#CCCCCC", "#666666"]),
+            }
+        )
+        self.active_theme: Theme = self.themes["electric"]
+        self._load_from_file()
+
+    def _load_from_file(self) -> None:
+        if not self.CONFIG_FILE.exists():
+            return
+        try:
+            data = json.loads(self.CONFIG_FILE.read_text())
+        except Exception:
+            return
+        theme_name = data.get("theme")
+        if theme_name and theme_name in self.themes:
+            self.active_theme = self.themes[theme_name]
+
+    def _save_to_file(self) -> None:
+        try:
+            self.CONFIG_FILE.write_text(json.dumps({"theme": self.active_theme.name}))
+        except Exception:
+            pass
+
+    def get_theme(self) -> Theme:
+        if os.environ.get("NO_COLOR"):
+            return Theme("nocolor", ["white"])
+        return self.active_theme
+
+    def set_theme(self, name: str) -> None:
+        if name not in self.themes:
+            raise ValueError(f"Unknown theme: {name}")
+        self.active_theme = self.themes[name]
+        self._save_to_file()
+
+    def available_themes(self) -> Iterable[str]:
+        return self.themes.keys()
+
+
+# Singleton theme manager used across the application
+theme_manager = ThemeManager()
 
 # Default electric theme used by the Terminal UI
-ELECTRIC_THEME = get_theme("electric")
+ELECTRIC_THEME = theme_manager.get_theme()


### PR DESCRIPTION
## Summary
- add theme manager with persistent selection and `/theme` command
- show banner before prompting and support rich prompt with history
- enhance progress spinner with elapsed time
- render plans and files with Rich panels
- document theme switching in README

## Testing
- `ruff check circuitron/ui/app.py circuitron/utils.py circuitron/cli.py circuitron/ui/themes.py`
- `mypy circuitron/ui/app.py circuitron/utils.py circuitron/ui/themes.py circuitron/cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872813d391883339291cccc61a2e8df