### PR TITLE
Improve network timeout handling

### DIFF
--- a/circuitron/debug.py
+++ b/circuitron/debug.py
@@ -50,11 +50,6 @@ async def run_agent(agent: Any, input_data: Any) -> RunResult:
     Returns:
         The :class:`RunResult` from the agent run.
     """
-    if not is_connected():
-        raise PipelineError(
-            "Internet connection lost. Please check your connection and try again."
-        )
-
     try:
         coro = Runner.run(agent, input_data, max_turns=settings.max_turns)
         result = await asyncio.wait_for(coro, timeout=settings.network_timeout)
@@ -63,12 +58,16 @@ async def run_agent(agent: Any, input_data: Any) -> RunResult:
         print(message)
         raise PipelineError(message)
     except asyncio.TimeoutError:
+        if not is_connected(timeout=5.0):
+            raise PipelineError(
+                "Internet connection lost. Please check your connection and try again."
+            )
         raise PipelineError(
-            "Network operation timed out. Please check your connection and try again."
+            "Network operation timed out. Consider increasing CIRCUITRON_NETWORK_TIMEOUT."
         )
     except (httpx.HTTPError, openai.OpenAIError) as exc:
         print(f"Network error: {exc}")
-        if not is_connected():
+        if not is_connected(timeout=5.0):
             raise PipelineError(
                 "Internet connection lost. Please check your connection and try again."
             ) from exc

--- a/circuitron/mcp_manager.py
+++ b/circuitron/mcp_manager.py
@@ -7,6 +7,7 @@ import logging
 from agents.mcp import MCPServer
 
 from .tools import create_mcp_server
+from .config import settings
 
 
 class MCPManager:
@@ -24,7 +25,10 @@ class MCPManager:
         """Attempt to connect to the MCP server with retries."""
         for attempt in range(3):
             try:
-                await asyncio.wait_for(self._server.connect(), timeout=20.0)  # type: ignore[no-untyped-call]
+                await asyncio.wait_for(
+                    self._server.connect(),
+                    timeout=settings.network_timeout,
+                )  # type: ignore[no-untyped-call]
                 logging.info(
                     "Successfully connected to MCP server: %s", self._server.name
                 )

--- a/circuitron/network.py
+++ b/circuitron/network.py
@@ -6,7 +6,7 @@ import socket
 import httpx
 
 
-def is_connected(url: str = "https://api.openai.com", timeout: float = 3.0) -> bool:
+def is_connected(url: str = "https://api.openai.com", timeout: float = 10.0) -> bool:
     """Return ``True`` if ``url`` is reachable within ``timeout`` seconds.
 
     Args:

--- a/circuitron/settings.py
+++ b/circuitron/settings.py
@@ -40,6 +40,6 @@ class Settings:
         default_factory=lambda: int(os.getenv("CIRCUITRON_MAX_TURNS", "50"))
     )
     network_timeout: float = field(
-        default_factory=lambda: float(os.getenv("CIRCUITRON_NETWORK_TIMEOUT", "60"))
+        default_factory=lambda: float(os.getenv("CIRCUITRON_NETWORK_TIMEOUT", "300"))
     )
     dev_mode: bool = False

--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -176,7 +176,11 @@ print(json.dumps(filtered_results))
 """
     )
     try:
-        proc = await asyncio.to_thread(kicad_session.exec_python_with_env, script, timeout=120)
+        proc = await asyncio.to_thread(
+            kicad_session.exec_python_with_env,
+            script,
+            timeout=int(settings.network_timeout),
+        )
     except subprocess.TimeoutExpired as exc:
         return json.dumps({"error": "search timeout", "details": str(exc)})
     except subprocess.CalledProcessError as exc:
@@ -250,7 +254,11 @@ print(json.dumps(results))
 """
     )
     try:
-        proc = await asyncio.to_thread(kicad_session.exec_python_with_env, script, timeout=120)
+        proc = await asyncio.to_thread(
+            kicad_session.exec_python_with_env,
+            script,
+            timeout=int(settings.network_timeout),
+        )
     except subprocess.TimeoutExpired as exc:
         return json.dumps({"error": "footprint search timeout", "details": str(exc)})
     except subprocess.CalledProcessError as exc:
@@ -302,7 +310,11 @@ except Exception as exc:
     print(json.dumps({{"error": str(exc)}}))
 """)
     try:
-        proc = await asyncio.to_thread(kicad_session.exec_python_with_env, script, timeout=120)
+        proc = await asyncio.to_thread(
+            kicad_session.exec_python_with_env,
+            script,
+            timeout=int(settings.network_timeout),
+        )
     except subprocess.TimeoutExpired as exc:
         return json.dumps({"error": "pin extract timeout", "details": str(exc)})
     except subprocess.CalledProcessError as exc:
@@ -319,7 +331,7 @@ def create_mcp_server() -> MCPServerSse:
         MCPServerSse configured for the ``skidl_docs`` server.
     """
     url = f"{settings.mcp_url}/sse"
-    timeout = 15.0 if os.getenv("DOCKER_ENV") else 10.0
+    timeout = settings.network_timeout
     return MCPServerSse(
         name="skidl_docs",
         params={
@@ -375,7 +387,10 @@ async def run_runtime_check(script_path: str) -> str:
     )
     try:
         proc = await asyncio.to_thread(
-            kicad_session.exec_erc_with_env, script_path, wrapper
+            kicad_session.exec_erc_with_env,
+            script_path,
+            wrapper,
+            timeout=int(settings.network_timeout),
         )
     except subprocess.TimeoutExpired as exc:
         return json.dumps(
@@ -457,7 +472,12 @@ async def run_erc(script_path: str) -> str:
         """
     )
     try:
-        proc = await asyncio.to_thread(kicad_session.exec_erc_with_env, script_path, wrapper)
+        proc = await asyncio.to_thread(
+            kicad_session.exec_erc_with_env,
+            script_path,
+            wrapper,
+            timeout=int(settings.network_timeout),
+        )
     except subprocess.TimeoutExpired as exc:
         return json.dumps(
             {"success": False, "erc_passed": False, "stdout": "", "stderr": str(exc)}
@@ -520,7 +540,9 @@ set_default_tool(KICAD5)
     script_path = write_temp_skidl_script(wrapped_script)
     try:
         proc = await asyncio.to_thread(
-            session.exec_full_script_with_env, script_path
+            session.exec_full_script_with_env,
+            script_path,
+            timeout=int(settings.network_timeout),
         )
         success = proc.returncode == 0
         

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -145,9 +145,7 @@ def test_create_mcp_server() -> None:
     assert server.name == "skidl_docs"
     assert server.params["url"] == cfg.settings.mcp_url + "/sse"
     assert "timeout" in server.params
-    assert server.client_session_timeout_seconds == (
-        15.0 if os.getenv("DOCKER_ENV") else 10.0
-    )
+    assert server.client_session_timeout_seconds == cfg.settings.network_timeout
 
 
 def test_run_erc_success() -> None:


### PR DESCRIPTION
## Summary
- allow 5 minute default network timeout
- bump timeout in `is_connected`
- only check connectivity after errors in `run_agent` and guardrails
- expand MCP server timeout
- use `network_timeout` for KiCad tooling
- update tests for new timeout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68728e217c7c8333aba725737eebece7