### PR TITLE
Refactor agent initialization

### DIFF
--- a/circuitron/agents.py
+++ b/circuitron/agents.py
@@ -230,14 +230,85 @@ def create_erc_handling_agent() -> Agent:
     )
 
 
-# Create agent instances
-planner = create_planning_agent()
-plan_editor = create_plan_edit_agent()
-part_finder = create_partfinder_agent()
-part_selector = create_partselection_agent()
-documentation = create_documentation_agent()
-code_generator = create_code_generation_agent()
-code_validator = create_code_validation_agent()
-code_corrector = create_code_correction_agent()
-runtime_error_corrector = create_runtime_error_correction_agent()
-erc_handler = create_erc_handling_agent()
+def get_planning_agent() -> Agent:
+    """Return a new instance of the Planning Agent."""
+
+    return create_planning_agent()
+
+
+def get_plan_edit_agent() -> Agent:
+    """Return a new instance of the Plan Edit Agent."""
+
+    return create_plan_edit_agent()
+
+
+def get_partfinder_agent() -> Agent:
+    """Return a new instance of the PartFinder Agent."""
+
+    return create_partfinder_agent()
+
+
+def get_partselection_agent() -> Agent:
+    """Return a new instance of the Part Selection Agent."""
+
+    return create_partselection_agent()
+
+
+def get_documentation_agent() -> Agent:
+    """Return a new instance of the Documentation Agent."""
+
+    return create_documentation_agent()
+
+
+def get_code_generation_agent() -> Agent:
+    """Return a new instance of the Code Generation Agent."""
+
+    return create_code_generation_agent()
+
+
+def get_code_validation_agent() -> Agent:
+    """Return a new instance of the Code Validation Agent."""
+
+    return create_code_validation_agent()
+
+
+def get_code_correction_agent() -> Agent:
+    """Return a new instance of the Code Correction Agent."""
+
+    return create_code_correction_agent()
+
+
+def get_runtime_error_correction_agent() -> Agent:
+    """Return a new instance of the Runtime Error Correction Agent."""
+
+    return create_runtime_error_correction_agent()
+
+
+def get_erc_handling_agent() -> Agent:
+    """Return a new instance of the ERC Handling Agent."""
+
+    return create_erc_handling_agent()
+
+
+__all__ = [
+    "get_planning_agent",
+    "get_plan_edit_agent",
+    "get_partfinder_agent",
+    "get_partselection_agent",
+    "get_documentation_agent",
+    "get_code_generation_agent",
+    "get_code_validation_agent",
+    "get_code_correction_agent",
+    "get_runtime_error_correction_agent",
+    "get_erc_handling_agent",
+    "create_planning_agent",
+    "create_plan_edit_agent",
+    "create_partfinder_agent",
+    "create_partselection_agent",
+    "create_documentation_agent",
+    "create_code_generation_agent",
+    "create_code_validation_agent",
+    "create_code_correction_agent",
+    "create_runtime_error_correction_agent",
+    "create_erc_handling_agent",
+]

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 import circuitron.debug as dbg
-from circuitron.agents import planner
+from circuitron.agents import get_planning_agent
 from circuitron.guardrails import pcb_query_guardrail, PCBQueryOutput
 from circuitron.exceptions import PipelineError
 from agents.guardrail import GuardrailFunctionOutput
@@ -20,7 +20,7 @@ def test_non_pcb_prompt_triggers_guardrail(capsys: pytest.CaptureFixture[str], m
     monkeypatch.setattr(pcb_query_guardrail, "guardrail_function", mock_guardrail)
 
     with pytest.raises(PipelineError):
-        asyncio.run(dbg.run_agent(planner, "Tell me a joke"))
+        asyncio.run(dbg.run_agent(get_planning_agent(), "Tell me a joke"))
 
     mock_guardrail.assert_awaited_once()
     out = capsys.readouterr().out
@@ -35,6 +35,6 @@ def test_guardrail_network_failure(capsys: pytest.CaptureFixture[str], monkeypat
 
     monkeypatch.setattr(dbg.Runner, "run", raise_network)
     with pytest.raises(PipelineError):
-        asyncio.run(dbg.run_agent(planner, "design"))
+        asyncio.run(dbg.run_agent(get_planning_agent(), "design"))
     out = capsys.readouterr().out
     assert "network error" in out.lower()

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -24,7 +24,10 @@ async def run_wrappers() -> None:
          patch("circuitron.debug.Runner.run", AsyncMock()) as run_mock:
         run_mock.return_value = SimpleNamespace(final_output=PlanOutput())
         await pl.run_planner("p")
-        run_mock.assert_awaited_with(pl.planner, "p", max_turns=pl.settings.max_turns)  # type: ignore[attr-defined]
+        assert run_mock.await_args is not None
+        called_agent = run_mock.await_args.args[0]
+        assert called_agent.name == "Circuitron-Planner"
+        run_mock.assert_awaited()
         run_mock.reset_mock()
 
         run_mock.return_value = SimpleNamespace(final_output=PlanEditorOutput(decision=PlanEditDecision(reasoning="x"), updated_plan=PlanOutput()))


### PR DESCRIPTION
## Summary
- avoid creating agents before MCP server is connected
- supply factory functions for creating agents
- initialize agents after the MCP server setup in the pipeline
- update tests for new factory functions
- ensure pipeline module ends with a newline

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872990b845483338f00f8d6415e55e0