### PR TITLE
Fix MCP connection lifecycle in Terminal UI

### DIFF
--- a/circuitron/ui/app.py
+++ b/circuitron/ui/app.py
@@ -87,13 +87,23 @@ class TerminalUI:
         retries: int = 0,
         output_dir: str | None = None,
     ) -> utils.CodeGenerationOutput | None:
-        """Execute the Circuitron pipeline with UI feedback."""
-        from ..pipeline import run_with_retry
+        """Execute the Circuitron pipeline with UI feedback.
 
-        return await run_with_retry(
-            prompt,
-            show_reasoning=show_reasoning,
-            retries=retries,
-            output_dir=output_dir,
-            ui=self,
-        )
+        This method now manages the MCP server connection lifecycle so that the
+        pipeline has an initialized server before any agents run.
+        """
+
+        from ..pipeline import run_with_retry
+        from ..mcp_manager import mcp_manager
+
+        await mcp_manager.initialize()
+        try:
+            return await run_with_retry(
+                prompt,
+                show_reasoning=show_reasoning,
+                retries=retries,
+                output_dir=output_dir,
+                ui=self,
+            )
+        finally:
+            await mcp_manager.cleanup()


### PR DESCRIPTION
## Summary
- manage MCP initialization inside `TerminalUI.run`
- use knowledge base guidance that MCP servers must be connected before use

## Testing
- `ruff check .`
- `mypy circuitron tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a7f7937083338936b3b21c661908