### PR TITLE
Expose full metadata from PartFinder

### DIFF
--- a/circuitron/debug.py
+++ b/circuitron/debug.py
@@ -76,3 +76,5 @@ async def run_agent(agent: Any, input_data: Any) -> RunResult:
     if settings.dev_mode:
         display_run_items(result)
     return result
+
+__all__ = ["display_run_items", "run_agent", "Runner"]

--- a/circuitron/mcp_manager.py
+++ b/circuitron/mcp_manager.py
@@ -26,9 +26,9 @@ class MCPManager:
         for attempt in range(3):
             try:
                 await asyncio.wait_for(
-                    self._server.connect(),
+                    self._server.connect(),  # type: ignore[no-untyped-call]
                     timeout=settings.network_timeout,
-                )  # type: ignore[no-untyped-call]
+                )
                 logging.info(
                     "Successfully connected to MCP server: %s", self._server.name
                 )

--- a/circuitron/models.py
+++ b/circuitron/models.py
@@ -131,26 +131,21 @@ class FoundFootprint(BaseModel):
 
 class PartFinderOutput(BaseModel):
     """Output from the PartFinder agent."""
+
     model_config = ConfigDict(extra="forbid", strict=True)
-    found_components_json: str = Field(description="JSON mapping search query to list of found components. Only include queries that returned useful results.")
+
+    found_components: dict[str, list[FoundPart]] = Field(
+        default_factory=dict,
+        description="Mapping from each search query to the list of components found.",
+    )
 
     def get_total_components(self) -> int:
         """Get total number of components found across all searches."""
-        import json
-        try:
-            data = json.loads(self.found_components_json)
-            return sum(len(components) for components in data.values() if components)
-        except Exception:
-            return 0
+        return sum(len(comps) for comps in self.found_components.values() if comps)
     
     def get_successful_searches(self) -> int:
         """Get number of searches that returned results."""
-        import json
-        try:
-            data = json.loads(self.found_components_json)
-            return sum(1 for components in data.values() if components)
-        except Exception:
-            return 0
+        return sum(1 for comps in self.found_components.values() if comps)
 
 
 class PinDetail(BaseModel):

--- a/circuitron/network.py
+++ b/circuitron/network.py
@@ -42,4 +42,4 @@ def check_internet_connection() -> bool:
         return False
     return True
 
-__all__ = ["check_internet_connection", "is_connected"]
+__all__ = ["check_internet_connection", "is_connected", "httpx"]

--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -547,7 +547,7 @@ async def pipeline(
         ]
     ):
         part_output = await run_part_finder(plan, ui=ui, agent=partfinder_agent)
-        pretty_print_found_parts(part_output.found_components_json)
+        pretty_print_found_parts(part_output.found_components)
         selection = await run_part_selector(
             plan,
             part_output,
@@ -716,7 +716,7 @@ async def pipeline(
     final_plan = edit_result.updated_plan
 
     part_output = await run_part_finder(final_plan, agent=partfinder_agent)
-    pretty_print_found_parts(part_output.found_components_json)
+    pretty_print_found_parts(part_output.found_components)
     selection = await run_part_selector(final_plan, part_output, agent=partselection_agent)
     pretty_print_selected_parts(selection)
     docs = await run_documentation(final_plan, selection, agent=documentation_agent)

--- a/circuitron/ui/app.py
+++ b/circuitron/ui/app.py
@@ -16,7 +16,7 @@ from circuitron.logo import LOGO_ART, apply_gradient
 from .themes import Theme, theme_manager
 from .components.progress import StageSpinner
 from .. import utils
-from ..models import PlanOutput
+from ..models import PlanOutput, UserFeedback, CodeGenerationOutput
 
 
 class TerminalUI:
@@ -73,7 +73,7 @@ class TerminalUI:
         """Pretty print the generated plan."""
         utils.pretty_print_plan(plan, console=self.console)
 
-    def collect_feedback(self, plan: PlanOutput) -> utils.UserFeedback:
+    def collect_feedback(self, plan: PlanOutput) -> UserFeedback:
         return utils.collect_user_feedback(plan, input_func=self.prompt_user)
 
     def display_files(self, files: Iterable[str]) -> None:
@@ -86,7 +86,7 @@ class TerminalUI:
         show_reasoning: bool = False,
         retries: int = 0,
         output_dir: str | None = None,
-    ) -> utils.CodeGenerationOutput | None:
+    ) -> CodeGenerationOutput | None:
         """Execute the Circuitron pipeline with UI feedback.
 
         This method now manages the MCP server connection lifecycle so that the

--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -21,6 +21,7 @@ from .models import (
     DocumentationOutput,
     CodeGenerationOutput,
     CodeValidationOutput,
+    FoundPart,
 )
 from .correction_context import CorrectionContext
 
@@ -353,7 +354,10 @@ def format_part_selection_input(plan: PlanOutput, found: PartFinderOutput) -> st
             ]
         )
 
-    parts.extend(["FOUND COMPONENTS JSON:", found.found_components_json, ""])
+    import json
+
+    found_json = json.dumps(found.found_components)
+    parts.extend(["FOUND COMPONENTS JSON:", found_json, ""])
     parts.append("Select the best components and extract pin details.")
     return "\n".join(parts)
 
@@ -411,18 +415,20 @@ def pretty_print_edited_plan(edited_output: PlanEditorOutput) -> None:
         pretty_print_plan(edited_output.updated_plan)
 
 
-def pretty_print_found_parts(found_json: str) -> None:
+def pretty_print_found_parts(found_parts: dict[str, list[FoundPart]]) -> None:
     """Display the components found by the PartFinder agent.
 
     Args:
-        found_json: JSON string mapping each search query to a list of found parts.
+        found_parts: Mapping from search query to lists of found parts.
 
     Example:
-        >>> pretty_print_found_parts('[{"name": "LM324"}]')
+        >>> pretty_print_found_parts({"ic": [FoundPart(name="LM324", library="linear")]})
     """
 
+    import json
+
     print("\n=== FOUND COMPONENTS JSON ===\n")
-    print(found_json)
+    print(json.dumps(found_parts))
 
 
 def pretty_print_selected_parts(selection: PartSelectionOutput) -> None:

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -28,7 +28,7 @@ def test_non_pcb_prompt_triggers_guardrail(capsys: pytest.CaptureFixture[str], m
 
 
 def test_guardrail_network_failure(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
-    async def raise_network(*_a, **_k):
+    async def raise_network(*_a: object, **_k: object) -> None:
         import httpx
 
         raise httpx.RequestError("fail")

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -19,7 +19,7 @@ def test_run_agent_handles_network_error(capsys: pytest.CaptureFixture[str]) -> 
 
     with pytest.raises(PipelineError):
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(dbg.Runner, "run", fake_run)  # type: ignore[attr-defined]
+            mp.setattr(dbg.Runner, "run", fake_run)
             asyncio.run(dbg.run_agent(SimpleNamespace(name="a"), "x"))
     out = capsys.readouterr().out
     assert "network error" in out.lower()
@@ -36,7 +36,7 @@ def test_pcb_guardrail_handles_network_error(
     ctx = SimpleNamespace(context=None)
     with pytest.raises(PipelineError):
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(dbg.Runner, "run", fake_run)  # type: ignore[attr-defined]
+            mp.setattr(dbg.Runner, "run", fake_run)
             asyncio.run(gr.pcb_query_guardrail.guardrail_function(ctx, None, "x"))  # type: ignore[arg-type]
     out = capsys.readouterr().out
     assert "network error" in out.lower()

--- a/tests/test_part_selection.py
+++ b/tests/test_part_selection.py
@@ -22,7 +22,7 @@ async def fake_pipeline_no_feedback() -> None:
     import circuitron.pipeline as pl
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -49,7 +49,7 @@ async def fake_pipeline_edit_plan() -> None:
         decision=PlanEditDecision(reasoning="ok"),
         updated_plan=edited_plan,
     )
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -29,7 +29,7 @@ async def fake_pipeline_no_feedback() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=[])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -56,7 +56,7 @@ async def fake_pipeline_edit_plan() -> None:
         decision=PlanEditDecision(reasoning="ok"),
         updated_plan=edited_plan,
     )
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -148,7 +148,7 @@ async def fake_pipeline_with_correction() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput()
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok")
     code_out = CodeGenerationOutput(complete_skidl_code="init")
@@ -208,7 +208,7 @@ async def fake_pipeline_debug_show() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=["print(1)"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok")
     code_out = CodeGenerationOutput(complete_skidl_code="")
@@ -238,7 +238,7 @@ async def fake_pipeline_edit_plan_with_correction() -> None:
         decision=PlanEditDecision(reasoning="ok"),
         updated_plan=edited_plan,
     )
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok")
     code_out = CodeGenerationOutput(complete_skidl_code="init")
@@ -285,7 +285,7 @@ async def fake_pipeline_warning_approval_flow() -> None:
 
     plan = PlanOutput()
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok")
     code_out = CodeGenerationOutput(complete_skidl_code="init")
@@ -421,7 +421,7 @@ async def fake_pipeline_validation_error() -> None:
 
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -450,7 +450,7 @@ async def fake_pipeline_erc_error() -> None:
 
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -500,7 +500,7 @@ async def fake_pipeline_debug_failure(capsys: pytest.CaptureFixture[str]) -> str
 
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -539,7 +539,7 @@ async def fake_pipeline_warning_approval(capsys: pytest.CaptureFixture[str]) -> 
 
     plan = PlanOutput()
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components_json="[]")
+    part_out = PartFinderOutput(found_components={})
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -34,12 +34,12 @@ async def run_wrappers() -> None:
         await pl.run_plan_editor("p", PlanOutput(), UserFeedback())
         run_mock.reset_mock()
 
-        run_mock.return_value = SimpleNamespace(final_output=PartFinderOutput(found_components_json="[]"))
+        run_mock.return_value = SimpleNamespace(final_output=PartFinderOutput(found_components={}))
         await pl.run_part_finder(PlanOutput(component_search_queries=["Q"]))
         run_mock.reset_mock()
 
         run_mock.return_value = SimpleNamespace(final_output=PartSelectionOutput())
-        await pl.run_part_selector(PlanOutput(), PartFinderOutput(found_components_json="[]"))
+        await pl.run_part_selector(PlanOutput(), PartFinderOutput(found_components={}))
         run_mock.reset_mock()
 
         run_mock.return_value = SimpleNamespace(final_output=DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok"))

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -122,7 +122,7 @@ def test_pretty_print_helpers(capsys: pytest.CaptureFixture[str]) -> None:
     # edited plan
     edit = PlanEditorOutput(decision=PlanEditDecision(reasoning="r"), updated_plan=plan)
     pretty_print_edited_plan(edit)
-    pretty_print_found_parts("[]")
+    pretty_print_found_parts({})
     selected = PartSelectionOutput(
         selections=[
             SelectedPart(name="U1", library="lib", footprint="fp", pin_details=[])


### PR DESCRIPTION
## Summary
- extend `PartFinderOutput` to hold `FoundPart` objects
- adapt utilities and pipeline to format and display new data
- update tests for new `found_components` field
- export `httpx` in `network` and expose `Runner` from `debug`
- fix type hints and remove unused ignores

## Testing
- `ruff check circuitron/models.py circuitron/utils.py circuitron/pipeline.py tests/test_part_selection.py tests/test_pipeline.py tests/test_pipeline_wrappers.py tests/test_utils_extra.py circuitron/network.py circuitron/mcp_manager.py tests/test_network.py tests/test_guardrails.py circuitron/ui/app.py circuitron/debug.py`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872cdbca01c83338e583131ecf4cee9