### PR TITLE
Fix PartFinder model for strict schema

### DIFF
--- a/circuitron/models.py
+++ b/circuitron/models.py
@@ -134,23 +134,32 @@ class FoundFootprint(BaseModel):
     package_type: str | None = None
 
 
+class PartSearchResult(BaseModel):
+    """Components found for a given search query."""
+
+    model_config = ConfigDict(strict=True)
+
+    query: str
+    components: List[FoundPart] = Field(default_factory=list)
+
+
 class PartFinderOutput(BaseModel):
     """Output from the PartFinder agent."""
 
     model_config = ConfigDict(extra="forbid", strict=True)
 
-    found_components: Dict[str, List[FoundPart]] = Field(
-        default_factory=dict,
-        description="Mapping from each search query to the list of components found.",
+    found_components: List[PartSearchResult] = Field(
+        default_factory=list,
+        description="Results for each component search query.",
     )
 
     def get_total_components(self) -> int:
         """Get total number of components found across all searches."""
-        return sum(len(comps) for comps in self.found_components.values() if comps)
-    
+        return sum(len(res.components) for res in self.found_components if res.components)
+
     def get_successful_searches(self) -> int:
         """Get number of searches that returned results."""
-        return sum(1 for comps in self.found_components.values() if comps)
+        return sum(1 for res in self.found_components if res.components)
 
 
 class PinDetail(BaseModel):

--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -22,6 +22,7 @@ from .models import (
     CodeGenerationOutput,
     CodeValidationOutput,
     FoundPart,
+    PartSearchResult,
 )
 from .correction_context import CorrectionContext
 
@@ -356,7 +357,7 @@ def format_part_selection_input(plan: PlanOutput, found: PartFinderOutput) -> st
 
     import json
 
-    found_json = json.dumps(found.found_components)
+    found_json = json.dumps(found.model_dump()["found_components"])
     parts.extend(["FOUND COMPONENTS JSON:", found_json, ""])
     parts.append("Select the best components and extract pin details.")
     return "\n".join(parts)
@@ -415,20 +416,22 @@ def pretty_print_edited_plan(edited_output: PlanEditorOutput) -> None:
         pretty_print_plan(edited_output.updated_plan)
 
 
-def pretty_print_found_parts(found_parts: dict[str, list[FoundPart]]) -> None:
+def pretty_print_found_parts(found_parts: list[PartSearchResult]) -> None:
     """Display the components found by the PartFinder agent.
 
     Args:
-        found_parts: Mapping from search query to lists of found parts.
+        found_parts: List of search results from the PartFinder agent.
 
     Example:
-        >>> pretty_print_found_parts({"ic": [FoundPart(name="LM324", library="linear")]})
+        >>> pretty_print_found_parts([
+        ...     PartSearchResult(query="ic", components=[FoundPart(name="LM324", library="linear")])
+        ... ])
     """
 
     import json
 
     print("\n=== FOUND COMPONENTS JSON ===\n")
-    print(json.dumps(found_parts))
+    print(json.dumps([res.model_dump() for res in found_parts]))
 
 
 def pretty_print_selected_parts(selection: PartSelectionOutput) -> None:

--- a/tests/test_part_selection.py
+++ b/tests/test_part_selection.py
@@ -22,7 +22,7 @@ async def fake_pipeline_no_feedback() -> None:
     import circuitron.pipeline as pl
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -49,7 +49,7 @@ async def fake_pipeline_edit_plan() -> None:
         decision=PlanEditDecision(reasoning="ok"),
         updated_plan=edited_plan,
     )
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -29,7 +29,7 @@ async def fake_pipeline_no_feedback() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=[])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -56,7 +56,7 @@ async def fake_pipeline_edit_plan() -> None:
         decision=PlanEditDecision(reasoning="ok"),
         updated_plan=edited_plan,
     )
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -148,7 +148,7 @@ async def fake_pipeline_with_correction() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput()
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok")
     code_out = CodeGenerationOutput(complete_skidl_code="init")
@@ -208,7 +208,7 @@ async def fake_pipeline_debug_show() -> None:
     from circuitron import pipeline as pl
     plan = PlanOutput(component_search_queries=["R"], calculation_codes=["print(1)"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok")
     code_out = CodeGenerationOutput(complete_skidl_code="")
@@ -238,7 +238,7 @@ async def fake_pipeline_edit_plan_with_correction() -> None:
         decision=PlanEditDecision(reasoning="ok"),
         updated_plan=edited_plan,
     )
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok")
     code_out = CodeGenerationOutput(complete_skidl_code="init")
@@ -285,7 +285,7 @@ async def fake_pipeline_warning_approval_flow() -> None:
 
     plan = PlanOutput()
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok")
     code_out = CodeGenerationOutput(complete_skidl_code="init")
@@ -421,7 +421,7 @@ async def fake_pipeline_validation_error() -> None:
 
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -450,7 +450,7 @@ async def fake_pipeline_erc_error() -> None:
 
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -500,7 +500,7 @@ async def fake_pipeline_debug_failure(capsys: pytest.CaptureFixture[str]) -> str
 
     plan = PlanOutput(component_search_queries=["R"])
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"
@@ -539,7 +539,7 @@ async def fake_pipeline_warning_approval(capsys: pytest.CaptureFixture[str]) -> 
 
     plan = PlanOutput()
     plan_result = SimpleNamespace(final_output=plan, new_items=[])
-    part_out = PartFinderOutput(found_components={})
+    part_out = PartFinderOutput()
     select_out = PartSelectionOutput()
     doc_out = DocumentationOutput(
         research_queries=[], documentation_findings=[], implementation_readiness="ok"

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -34,12 +34,12 @@ async def run_wrappers() -> None:
         await pl.run_plan_editor("p", PlanOutput(), UserFeedback())
         run_mock.reset_mock()
 
-        run_mock.return_value = SimpleNamespace(final_output=PartFinderOutput(found_components={}))
+        run_mock.return_value = SimpleNamespace(final_output=PartFinderOutput())
         await pl.run_part_finder(PlanOutput(component_search_queries=["Q"]))
         run_mock.reset_mock()
 
         run_mock.return_value = SimpleNamespace(final_output=PartSelectionOutput())
-        await pl.run_part_selector(PlanOutput(), PartFinderOutput(found_components={}))
+        await pl.run_part_selector(PlanOutput(), PartFinderOutput())
         run_mock.reset_mock()
 
         run_mock.return_value = SimpleNamespace(final_output=DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok"))

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -122,7 +122,7 @@ def test_pretty_print_helpers(capsys: pytest.CaptureFixture[str]) -> None:
     # edited plan
     edit = PlanEditorOutput(decision=PlanEditDecision(reasoning="r"), updated_plan=plan)
     pretty_print_edited_plan(edit)
-    pretty_print_found_parts({})
+    pretty_print_found_parts([])
     selected = PartSelectionOutput(
         selections=[
             SelectedPart(name="U1", library="lib", footprint="fp", pin_details=[])


### PR DESCRIPTION
## Summary
- refactor `PartFinderOutput` to remove typed dictionaries
- adjust utility functions and pretty printing for new structure
- update tests for new model

## Testing
- `pip install -e .`
- `pip install prompt_toolkit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872df08a5a483338eb45413b7090beb