### PR TITLE
Implement modern terminal UI with themed components

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -8,6 +8,7 @@ from .mcp_manager import mcp_manager
 from .network import check_internet_connection
 from .exceptions import PipelineError
 from circuitron.ui.app import TerminalUI
+from circuitron.ui.components import panel
 
 
 async def run_circuitron(
@@ -81,12 +82,10 @@ def main() -> None:
         kicad_session.stop()
 
     if code_output:
-        print("\n=== GENERATED SKiDL CODE ===\n")
-        print(code_output.complete_skidl_code)
-        print("\n" + "=" * 60)
-        print("📁 Generated files have been saved to the output directory.")
-        print("💡 Use --output-dir to specify a custom location.")
-        print("💡 Default location: ./circuitron_output")
+        panel.show_panel(ui.console, "Generated SKiDL Code", code_output.complete_skidl_code, ui.theme)
+        ui.console.print("\n📁 Generated files have been saved to the output directory.")
+        ui.console.print("💡 Use --output-dir to specify a custom location.")
+        ui.console.print("💡 Default location: ./circuitron_output")
 
 
 if __name__ == "__main__":

--- a/circuitron/ui/components/banner.py
+++ b/circuitron/ui/components/banner.py
@@ -1,0 +1,22 @@
+"""Banner component for displaying the Circuitron logo with a gradient."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.text import Text
+
+from ... import logo
+from ..themes import Theme
+
+
+class Banner:
+    """Render the Circuitron ASCII art banner."""
+
+    def __init__(self, console: Console) -> None:
+        self.console = console
+
+    def show(self, theme: Theme) -> None:
+        """Display the banner using ``theme`` gradient colors."""
+        text = Text.from_ansi(logo.LOGO_ART)
+        gradient = logo.apply_gradient(text, theme.gradient_colors)
+        self.console.print(gradient, justify="center")

--- a/circuitron/ui/components/panel.py
+++ b/circuitron/ui/components/panel.py
@@ -1,0 +1,15 @@
+"""Utility for themed panels."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+
+from ..themes import Theme
+
+
+def show_panel(console: Console, title: str, content: str, theme: Theme) -> None:
+    """Render ``content`` markdown inside a styled panel."""
+    panel = Panel(Markdown(content), title=title, border_style=theme.accent, expand=False)
+    console.print(panel)

--- a/circuitron/ui/components/prompt.py
+++ b/circuitron/ui/components/prompt.py
@@ -1,0 +1,31 @@
+"""Interactive prompt component using ``prompt_toolkit``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from prompt_toolkit import PromptSession  # type: ignore
+from prompt_toolkit.history import FileHistory  # type: ignore
+from prompt_toolkit.key_binding import KeyBindings  # type: ignore
+from rich.console import Console
+
+from ..themes import Theme
+
+
+class Prompt:
+    """Collect user input with history and theming."""
+
+    def __init__(self, console: Console, theme: Theme) -> None:
+        self.console = console
+        self.theme = theme
+        history_file = Path.home() / ".circuitron_history"
+        bindings = KeyBindings()
+        bindings.add("c-a")(lambda event: event.current_buffer.cursor_home())
+        bindings.add("c-e")(lambda event: event.current_buffer.cursor_end())
+        bindings.add("c-l")(lambda event: event.app.renderer.clear())
+        self.session = PromptSession(history=FileHistory(str(history_file)), key_bindings=bindings)
+
+    def ask(self, message: str) -> str:
+        """Return user input for ``message``."""
+        prompt_text = f"[{self.theme.accent}]{message}: [/bold]"
+        return self.session.prompt(prompt_text)

--- a/circuitron/ui/components/spinner.py
+++ b/circuitron/ui/components/spinner.py
@@ -1,0 +1,33 @@
+"""Enhanced spinner with elapsed time."""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+from rich.console import Console
+from rich.status import Status
+
+from ..themes import Theme
+
+
+class Spinner:
+    """Display a spinner while a stage runs."""
+
+    def __init__(self, console: Console, theme: Theme) -> None:
+        self.console = console
+        self.theme = theme
+        self.status: Status | None = None
+        self.start_time = 0.0
+
+    def start(self, stage: str) -> None:
+        self.start_time = perf_counter()
+        self.status = self.console.status(f"[{self.theme.accent}]{stage}...", spinner="dots")
+        self.status.start()
+
+    def stop(self, stage: str) -> None:
+        if not self.status:
+            return
+        elapsed = perf_counter() - self.start_time
+        self.status.update(f"[green]{stage} complete ({elapsed:.1f}s)")
+        self.status.stop()
+        self.status = None

--- a/circuitron/ui/components/status_bar.py
+++ b/circuitron/ui/components/status_bar.py
@@ -1,0 +1,49 @@
+"""Simple persistent status bar."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from rich.console import Console
+from rich.live import Live
+from rich.text import Text
+
+from ..themes import Theme
+
+
+@dataclass
+class Status:
+    """Current pipeline status."""
+
+    stage: str = "Idle"
+    message: str = ""
+
+
+class StatusBar:
+    """Display current pipeline stage and message."""
+
+    def __init__(self, console: Console, theme: Theme) -> None:
+        self.console = console
+        self.theme = theme
+        self.status = Status()
+        self._live: Optional[Live] = None
+
+    def start(self) -> None:
+        self._live = Live(refresh_per_second=4, console=self.console)
+        self._live.__enter__()
+        self.update()
+
+    def stop(self) -> None:
+        if self._live:
+            self._live.__exit__(None, None, None)
+            self._live = None
+
+    def update(self, stage: str | None = None, message: str | None = None) -> None:
+        if stage is not None:
+            self.status.stage = stage
+        if message is not None:
+            self.status.message = message
+        if self._live:
+            text = Text(f"{self.status.stage} - {self.status.message}", style=self.theme.accent)
+            self._live.update(text)

--- a/circuitron/ui/components/tables.py
+++ b/circuitron/ui/components/tables.py
@@ -1,0 +1,33 @@
+"""Table rendering helpers."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from rich.console import Console
+from rich.table import Table
+
+from ..themes import Theme
+from ...models import SelectedPart, FoundPart
+
+
+def show_found_parts(console: Console, parts: dict[str, list[FoundPart]], theme: Theme) -> None:
+    """Render table of found components."""
+    for query, plist in parts.items():
+        table = Table(title=f"Results for {query}", border_style=theme.accent)
+        table.add_column("Name")
+        table.add_column("Library")
+        for part in plist:
+            table.add_row(part.name, part.library)
+        console.print(table)
+
+
+def show_selected_parts(console: Console, parts: Iterable[SelectedPart], theme: Theme) -> None:
+    """Render table of selected components."""
+    table = Table(title="Selected Components", border_style=theme.accent)
+    table.add_column("Name")
+    table.add_column("Library")
+    table.add_column("Footprint")
+    for part in parts:
+        table.add_row(part.name, part.library, part.footprint or "")
+    console.print(table)

--- a/circuitron/ui/themes.py
+++ b/circuitron/ui/themes.py
@@ -27,14 +27,14 @@ class ThemeManager:
 
     def __init__(self) -> None:
         self.themes: Dict[str, Theme] = {
-            name: Theme(name=name, gradient_colors=colors)
+            name: Theme(name=name, gradient_colors=colors, accent="cyan")
             for name, colors in logo.THEMES.items()
         }
         # Built-in additional themes
         self.themes.update(
             {
-                "dark": Theme("dark", ["#1E1E2E", "#89B4FA", "#CBA6F7"]),
-                "light": Theme("light", ["#FFFFFF", "#CCCCCC", "#666666"]),
+                "dark": Theme("dark", ["#1E1E2E", "#89B4FA", "#CBA6F7"], accent="#89B4FA"),
+                "light": Theme("light", ["#FFFFFF", "#CCCCCC", "#666666"], accent="#4682B4"),
             }
         )
         self.active_theme: Theme = self.themes["electric"]
@@ -59,7 +59,7 @@ class ThemeManager:
 
     def get_theme(self) -> Theme:
         if os.environ.get("NO_COLOR"):
-            return Theme("nocolor", ["white"])
+            return Theme("nocolor", ["white"], accent="white")
         return self.active_theme
 
     def set_theme(self, name: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "skidl>=2.0.1",
     "httpx>=0.27.0",
+    "prompt_toolkit>=3.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai-agents==0.1.0
 python-dotenv>=1.1.0
 skidl>=2.0.1
 httpx>=0.27.0
+prompt_toolkit>=3.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,7 +39,7 @@ def test_cli_main_uses_args_and_prints(capsys: pytest.CaptureFixture[str]) -> No
          patch("circuitron.ui.app.TerminalUI.run", AsyncMock(return_value=out)):
         cli.main()
     captured = capsys.readouterr().out
-    assert "GENERATED SKiDL CODE" in captured
+    assert "Generated SKiDL Code" in captured
     assert "abc" in captured
 
 


### PR DESCRIPTION
## Summary
- add rich UI components for banner, prompt, panels, spinner, status bar and tables
- build theme manager and integrate with TerminalUI
- enhance TerminalUI with new component-driven layout and status updates
- refactor pipeline and CLI to use new display helpers
- update dependencies and tests for prompt_toolkit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d7c326d483339ca1c38c332d290d