### PR TITLE
Integrate footprint results into part selection

### DIFF
--- a/circuitron/models.py
+++ b/circuitron/models.py
@@ -3,7 +3,7 @@ Pydantic models for structured outputs in the Circuitron pipeline.
 Defines all BaseModels required for getting structured outputs from agents.
 """
 
-from typing import List, Literal, Dict
+from typing import List, Literal
 from pydantic import BaseModel, Field, ConfigDict, model_validator
 
 
@@ -152,10 +152,18 @@ class PartFinderOutput(BaseModel):
         default_factory=list,
         description="Results for each component search query.",
     )
+    found_footprints: List[FoundFootprint] = Field(
+        default_factory=list,
+        description="Footprints discovered for the searched components.",
+    )
 
     def get_total_components(self) -> int:
         """Get total number of components found across all searches."""
         return sum(len(res.components) for res in self.found_components if res.components)
+
+    def get_total_footprints(self) -> int:
+        """Get total number of footprints found across all searches."""
+        return len(self.found_footprints)
 
     def get_successful_searches(self) -> int:
         """Get number of searches that returned results."""

--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -76,6 +76,7 @@ from circuitron.utils import (
     pretty_print_generated_code,
     validate_code_generation_results,
     format_docs_summary,
+    format_plan_summary,
 )
 from circuitron.ui.components import panel
 
@@ -561,7 +562,7 @@ async def pipeline(
         if ui:
             ui.display_found_parts(part_output.found_components)
         else:
-            pretty_print_found_parts(part_output.found_components)
+            pretty_print_found_parts(part_output)
         selection = await run_part_selector(
             plan,
             part_output,
@@ -579,7 +580,7 @@ async def pipeline(
             agent=documentation_agent,
         )
         if ui:
-            panel.show_panel(ui.console, "Documentation", utils.format_docs_summary(docs), ui.theme)
+            panel.show_panel(ui.console, "Documentation", format_docs_summary(docs), ui.theme)
         else:
             pretty_print_documentation(docs)
         code_out = await run_code_generation(
@@ -732,7 +733,7 @@ async def pipeline(
         agent=plan_edit_agent,
     )
     if ui:
-        panel.show_panel(ui.console, "Plan Updated", utils.format_plan_summary(edit_result.updated_plan), ui.theme)
+        panel.show_panel(ui.console, "Plan Updated", format_plan_summary(edit_result.updated_plan), ui.theme)
     else:
         pretty_print_edited_plan(edit_result)
     assert edit_result.updated_plan is not None
@@ -742,7 +743,7 @@ async def pipeline(
     if ui:
         ui.display_found_parts(part_output.found_components)
     else:
-        pretty_print_found_parts(part_output.found_components)
+        pretty_print_found_parts(part_output)
     selection = await run_part_selector(final_plan, part_output, agent=partselection_agent)
     if ui:
         ui.display_selected_parts(selection.selections)
@@ -750,7 +751,7 @@ async def pipeline(
         pretty_print_selected_parts(selection)
     docs = await run_documentation(final_plan, selection, agent=documentation_agent)
     if ui:
-        panel.show_panel(ui.console, "Documentation", utils.format_docs_summary(docs), ui.theme)
+        panel.show_panel(ui.console, "Documentation", format_docs_summary(docs), ui.theme)
     else:
         pretty_print_documentation(docs)
     code_out = await run_code_generation(final_plan, selection, docs, agent=codegen_agent)

--- a/circuitron/ui/app.py
+++ b/circuitron/ui/app.py
@@ -16,8 +16,8 @@ from ..models import (
     PlanOutput,
     UserFeedback,
     CodeGenerationOutput,
-    FoundPart,
     SelectedPart,
+    PartSearchResult,
 )
 
 
@@ -82,8 +82,9 @@ class TerminalUI:
         links = "\n".join(f"[link=file://{p}]{p}[/]" for p in files)
         panel.show_panel(self.console, "Generated Files", links, self.theme)
 
-    def display_found_parts(self, found: dict[str, list[FoundPart]]) -> None:
-        tables.show_found_parts(self.console, found, self.theme)
+    def display_found_parts(self, found: Iterable[PartSearchResult]) -> None:
+        data = {res.query: res.components for res in found}
+        tables.show_found_parts(self.console, data, self.theme)
 
     def display_selected_parts(self, parts: Iterable[SelectedPart]) -> None:
         tables.show_selected_parts(self.console, parts, self.theme)

--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -21,8 +21,6 @@ from .models import (
     DocumentationOutput,
     CodeGenerationOutput,
     CodeValidationOutput,
-    FoundPart,
-    PartSearchResult,
 )
 from .correction_context import CorrectionContext
 
@@ -357,8 +355,8 @@ def format_part_selection_input(plan: PlanOutput, found: PartFinderOutput) -> st
 
     import json
 
-    found_json = json.dumps(found.model_dump()["found_components"])
-    parts.extend(["FOUND COMPONENTS JSON:", found_json, ""])
+    found_json = json.dumps(found.model_dump())
+    parts.extend(["PART SEARCH RESULTS JSON:", found_json, ""])
     parts.append("Select the best components and extract pin details.")
     return "\n".join(parts)
 
@@ -416,22 +414,20 @@ def pretty_print_edited_plan(edited_output: PlanEditorOutput) -> None:
         pretty_print_plan(edited_output.updated_plan)
 
 
-def pretty_print_found_parts(found_parts: list[PartSearchResult]) -> None:
-    """Display the components found by the PartFinder agent.
+def pretty_print_found_parts(found: PartFinderOutput) -> None:
+    """Display the components and footprints found by the PartFinder agent.
 
     Args:
-        found_parts: List of search results from the PartFinder agent.
+        found: The :class:`PartFinderOutput` from the agent.
 
     Example:
-        >>> pretty_print_found_parts([
-        ...     PartSearchResult(query="ic", components=[FoundPart(name="LM324", library="linear")])
-        ... ])
+        >>> pretty_print_found_parts(PartFinderOutput())
     """
 
     import json
 
-    print("\n=== FOUND COMPONENTS JSON ===\n")
-    print(json.dumps([res.model_dump() for res in found_parts]))
+    print("\n=== FOUND COMPONENTS AND FOOTPRINTS JSON ===\n")
+    print(json.dumps(found.model_dump()))
 
 
 def pretty_print_selected_parts(selection: PartSelectionOutput) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,10 @@ from circuitron.models import (
     APIValidationResult,
     KnowledgeGraphValidationReport,
     CodeValidationOutput,
+    PartFinderOutput,
+    PartSearchResult,
+    FoundPart,
+    FoundFootprint,
 )
 
 
@@ -69,3 +73,15 @@ def test_code_validation_output() -> None:
     )
     assert out.status == "pass"
     assert out.issues[0].category == "syntax"
+
+
+def test_partfinder_output_with_footprints() -> None:
+    """Verify PartFinderOutput stores footprints and counts them."""
+    part = FoundPart(name="R", library="Device")
+    footprint = FoundFootprint(name="0603", library="Resistor_SMD")
+    result = PartFinderOutput(
+        found_components=[PartSearchResult(query="resistor", components=[part])],
+        found_footprints=[footprint],
+    )
+    assert result.get_total_components() == 1
+    assert result.get_total_footprints() == 1

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -18,6 +18,9 @@ from circuitron.models import (
     CodeValidationOutput,
     DocumentationOutput,
     PartSelectionOutput,
+    PartFinderOutput,
+    PartSearchResult,
+    FoundFootprint,
     PinDetail,
     SelectedPart,
     ValidationIssue,
@@ -32,6 +35,7 @@ from circuitron.utils import (
     pretty_print_selected_parts,
     pretty_print_documentation,
     pretty_print_generated_code,
+    format_part_selection_input,
     collect_user_feedback,
     pretty_print_validation,
     write_temp_skidl_script,
@@ -99,6 +103,16 @@ def test_format_code_validation_and_correction_input() -> None:
     assert "erc_passed" in corr
 
 
+def test_format_part_selection_input_includes_footprints() -> None:
+    plan = PlanOutput(component_search_queries=["R"])
+    part_output = PartFinderOutput(
+        found_components=[PartSearchResult(query="R")],
+        found_footprints=[FoundFootprint(name="0603", library="Resistor_SMD")],
+    )
+    text = format_part_selection_input(plan, part_output)
+    assert "found_footprints" in text
+
+
 def test_pretty_print_helpers(capsys: pytest.CaptureFixture[str]) -> None:
     from circuitron.models import (
         PlanEditDecision,
@@ -122,7 +136,7 @@ def test_pretty_print_helpers(capsys: pytest.CaptureFixture[str]) -> None:
     # edited plan
     edit = PlanEditorOutput(decision=PlanEditDecision(reasoning="r"), updated_plan=plan)
     pretty_print_edited_plan(edit)
-    pretty_print_found_parts([])
+    pretty_print_found_parts(PartFinderOutput())
     selected = PartSelectionOutput(
         selections=[
             SelectedPart(name="U1", library="lib", footprint="fp", pin_details=[])


### PR DESCRIPTION
## Summary
- extend `PartFinderOutput` with `found_footprints`
- surface footprint data in `format_part_selection_input`
- show footprints when printing part search results
- adjust pipeline and UI to use updated structures
- test new model behaviour and input formatter

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872eb82e6f483339081cfedeee2b3e1