### PR TITLE
Add toggle for footprint search

### DIFF
--- a/circuitron/agents.py
+++ b/circuitron/agents.py
@@ -18,6 +18,7 @@ from .prompts import (
     PLAN_PROMPT,
     PLAN_EDIT_PROMPT,
     PARTFINDER_PROMPT,
+    PARTFINDER_PROMPT_NO_FOOTPRINT,
     PART_SELECTION_PROMPT,
     DOC_AGENT_PROMPT,
     CODE_GENERATION_PROMPT,
@@ -90,15 +91,27 @@ def create_plan_edit_agent() -> Agent:
     )
 
 
-def create_partfinder_agent() -> Agent:
-    """Create and configure the PartFinder Agent."""
+def create_partfinder_agent(footprint_search_enabled: bool = True) -> Agent:
+    """Create and configure the PartFinder Agent.
+
+    Args:
+        footprint_search_enabled: Include footprint search tool when ``True``.
+
+    Returns:
+        Configured :class:`~agents.Agent` instance.
+    """
     model_settings = ModelSettings(tool_choice="required")
 
-    tools: list[Tool] = [search_kicad_libraries, search_kicad_footprints]
+    tools: list[Tool] = [search_kicad_libraries]
+    prompt = PARTFINDER_PROMPT
+    if footprint_search_enabled:
+        tools.append(search_kicad_footprints)
+    else:
+        prompt = PARTFINDER_PROMPT_NO_FOOTPRINT
 
     return Agent(
         name="Circuitron-PartFinder",
-        instructions=PARTFINDER_PROMPT,
+        instructions=prompt,
         model=settings.part_finder_model,
         output_type=PartFinderOutput,
         tools=tools,
@@ -246,7 +259,7 @@ def get_plan_edit_agent() -> Agent:
 def get_partfinder_agent() -> Agent:
     """Return a new instance of the PartFinder Agent."""
 
-    return create_partfinder_agent()
+    return create_partfinder_agent(settings.footprint_search_enabled)
 
 
 def get_partselection_agent() -> Agent:

--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from rich.console import Console
-from .config import setup_environment
+from .config import setup_environment, settings
 from .models import CodeGenerationOutput
 from circuitron.tools import kicad_session
 from .mcp_manager import mcp_manager
@@ -55,6 +55,8 @@ def main() -> None:
 
     args = parse_args()
     setup_environment(dev=args.dev)
+    if args.no_footprint_search:
+        settings.footprint_search_enabled = False
 
     if not check_internet_connection():
         return

--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -897,9 +897,11 @@ async def pipeline(
 async def main() -> None:
     """CLI entry point for the Circuitron pipeline."""
     args = parse_args()
-    from circuitron.config import setup_environment
+    from circuitron.config import setup_environment, settings
 
     setup_environment(dev=args.dev)
+    if args.no_footprint_search:
+        settings.footprint_search_enabled = False
     if not check_internet_connection():
         return
     await mcp_manager.initialize()
@@ -945,6 +947,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=str,
         default=None,
         help="directory to save generated files (default: ./circuitron_output)",
+    )
+    parser.add_argument(
+        "--no-footprint-search",
+        action="store_true",
+        help="disable the agent's footprint search functionality",
     )
     return parser.parse_args(argv)
 

--- a/circuitron/prompts.py
+++ b/circuitron/prompts.py
@@ -128,7 +128,71 @@ The search tools will handle result limiting and smart prioritization. Your job 
 
 **Remember:** The next agent (PartSelector) will choose the best options, so focus on finding relevant candidates efficiently, not every possible variant.
 
-**After constructing focused queries, use the search tools to find the required parts and remember to find both parts and associated footprints.** 
+**After constructing focused queries, use the search tools to find the required parts and remember to find both parts and associated footprints.**
+"""
+
+PARTFINDER_PROMPT_NO_FOOTPRINT = f"""{RECOMMENDED_PROMPT_PREFIX}
+You are Circuitron-PartFinder, an expert in SKiDL component searches.
+
+Your task is to **find the most relevant components** using targeted SKiDL search queries. The search tools are intelligent and return results ordered by relevance, with smart filtering to prioritize basic components.
+
+**CRITICAL SEARCH INSIGHTS:**
+- Search results are **relevance-ordered** (exact matches first, then related components)
+- Search tools are **limited but smart-filtered** (50 symbol results)
+- **Basic components are auto-prioritized** (R, C, L appear before complex variants)
+- **Multiple strategic searches** often needed to find the right components
+
+**Search Strategy:**
+1. **Start with SPECIFIC terms** for known components (model numbers, exact names)
+2. **Use targeted functional queries** for generic components
+3. **Try alternative search terms** if first query doesn't yield good results
+
+**Query Construction Rules:**
+- **For specific ICs**: Use exact model names ("lm324", "ne555", "atmega328p")
+- **For basic passives**: Use simple terms ("resistor", "capacitor", "inductor") - basic symbols are auto-prioritized
+- **For specialized components**: Use descriptive terms ("mosfet n-channel", "opamp low-noise")
+- **For families**: Try both specific and generic terms ("74hc00", "logic gate")
+
+**Multi-Query Strategy Examples:**
+- *User*: "LM324 opamp"
+  → Try: "lm324" first (should find exact match at top)
+  → If needed: "opamp quad" (backup)
+
+- *User*: "resistor 1k"
+  → Try: "resistor" (will auto-prioritize basic "R" symbol)
+
+- *User*: "low noise opamp"
+  → Try: "opamp low noise" first
+  → Then: "opamp precision" or "opamp audio"
+  → Finally: "opamp" (generic fallback)
+
+**Stop Conditions:**
+- ✓ Found exact model match for specific components
+- ✓ Found basic symbol for generic passives (R, C, L)
+- ✓ Found 3-5 relevant candidates for the requirement
+- ✓ Search returns empty results (no more variants to try)
+
+**Efficiency Guidelines:**
+- **Don't over-search**: 2-3 strategic queries per component usually sufficient
+- **Trust the smart filtering**: Basic components will surface even in large result sets
+- **Skip redundant queries**: If "lm324" finds the part, don't also search "opamp"
+
+The search tools will handle result limiting and smart prioritization. Your job is to construct the RIGHT search terms to find suitable components efficiently.
+
+**Examples:**
+- *User query*: "capacitor 0.1uF 0603"
+    - Try: "capacitor" → STOP (generic symbol found)
+- *User query*: "opamp lm324 quad"
+    - Try: "^lm324$" → Found specific part? STOP
+    - Else: "lm324" → Found good matches? STOP
+    - Else: "opamp quad" → Continue only if needed
+- *User query*: "mosfet irf540n to-220"
+    - Try: "^irf540n$" → Found exact match? STOP
+    - Else: "irf540n" → Continue if needed
+
+**Remember:** The next agent (PartSelector) will choose the best options, so focus on finding relevant candidates efficiently, not every possible variant.
+
+**After constructing focused queries, use the search tools to find the required parts.**
 """
 
 # ---------- Part Selection Agent Prompt ----------

--- a/circuitron/settings.py
+++ b/circuitron/settings.py
@@ -43,3 +43,4 @@ class Settings:
         default_factory=lambda: float(os.getenv("CIRCUITRON_NETWORK_TIMEOUT", "300"))
     )
     dev_mode: bool = False
+    footprint_search_enabled: bool = True

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -36,6 +36,22 @@ def test_partfinder_includes_footprint_tool() -> None:
     assert "search_kicad_footprints" in tool_names
 
 
+def test_partfinder_disables_footprint_tool() -> None:
+    import sys
+
+    sys.modules.pop("circuitron.agents", None)
+    import circuitron.config as cfg
+
+    cfg.setup_environment()
+    cfg.settings.footprint_search_enabled = False
+    mod = importlib.import_module("circuitron.agents")
+    agent = mod.get_partfinder_agent()
+    tool_names = [tool.name for tool in agent.tools]
+    assert "search_kicad_footprints" not in tool_names
+    from circuitron import prompts
+    assert agent.instructions == prompts.PARTFINDER_PROMPT_NO_FOOTPRINT
+
+
 def test_partselector_includes_pin_tool() -> None:
     import sys
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -88,6 +88,13 @@ def test_parse_args() -> None:
     assert not hasattr(args, "debug")
     assert args.dev is True
     assert args.retries == 2
+    assert args.no_footprint_search is False
+
+
+def test_parse_args_no_footprint_flag() -> None:
+    from circuitron import pipeline as pl
+    args = pl.parse_args(["p", "--no-footprint-search"])
+    assert args.no_footprint_search is True
 
 
 def test_run_code_validation_calls_erc() -> None:

--- a/tests/test_pipeline_wrappers.py
+++ b/tests/test_pipeline_wrappers.py
@@ -95,7 +95,7 @@ def test_wrapper_functions() -> None:
 
 
 def test_pipeline_main(monkeypatch: pytest.MonkeyPatch) -> None:
-    args = SimpleNamespace(prompt="p", reasoning=False, retries=1, dev=False, output_dir=None)
+    args = SimpleNamespace(prompt="p", reasoning=False, retries=1, dev=False, output_dir=None, no_footprint_search=False)
     monkeypatch.setattr(pl, "parse_args", lambda _=None: args)
     monkeypatch.setattr(pl, "run_with_retry", AsyncMock())
     monkeypatch.setattr(pl, "check_internet_connection", lambda: False)


### PR DESCRIPTION
## Summary
- add `footprint_search_enabled` setting
- add `--no-footprint-search` CLI flag and plumb through pipeline
- update PartFinder agent to respect new setting and prompt
- ensure tests cover new toggle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68738f8a92d88333a429ba15209eb2f3