### PR TITLE
UI polish and output refactor

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -86,9 +86,9 @@ def main() -> None:
 
     if code_output:
         ui.display_code(code_output.complete_skidl_code)
-        ui.display_info("\n📁 Generated files have been saved to the output directory.")
-        ui.display_info("💡 Use --output-dir to specify a custom location.")
-        ui.display_info("💡 Default location: ./circuitron_output")
+        ui.display_info("\nGenerated files have been saved to the output directory.")
+        ui.display_info("Use --output-dir to specify a custom location.")
+        ui.display_info("Default location: ./circuitron_output")
 
 
 if __name__ == "__main__":

--- a/circuitron/ui/components/input_box.py
+++ b/circuitron/ui/components/input_box.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from rich.console import Console
-from rich.panel import Panel
-from rich.markdown import Markdown
 from prompt_toolkit import PromptSession  # type: ignore
 from prompt_toolkit.history import InMemoryHistory  # type: ignore
 
@@ -15,12 +13,12 @@ class InputBox:
     def __init__(self, console: Console, theme: Theme) -> None:
         self.console = console
         self.theme = theme
-        self.session = PromptSession(history=InMemoryHistory())
+        self.session: PromptSession = PromptSession(history=InMemoryHistory())
 
     def ask(self, message: str) -> str:
-        panel = Panel(Markdown(message), border_style=self.theme.accent, expand=False)
-        self.console.print(panel)
+        """Return user input for ``message`` using prompt_toolkit."""
+        prompt_text = f"[{self.theme.accent}]{message}:[/] "
         try:
-            return self.session.prompt("")
+            return self.session.prompt(prompt_text)
         except Exception:
-            return input("{0} ".format(message))
+            return input(f"{message}: ")

--- a/circuitron/ui/components/prompt.py
+++ b/circuitron/ui/components/prompt.py
@@ -24,7 +24,9 @@ class Prompt:
         bindings.add("c-a")(lambda event: event.current_buffer.cursor_home())
         bindings.add("c-e")(lambda event: event.current_buffer.cursor_end())
         bindings.add("c-l")(lambda event: event.app.renderer.clear())
-        self.session = PromptSession(history=FileHistory(str(history_file)), key_bindings=bindings)
+        self.session: PromptSession = PromptSession(
+            history=FileHistory(str(history_file)), key_bindings=bindings
+        )
 
     def ask(self, message: str) -> str:
         """Return user input for ``message``."""

--- a/circuitron/ui/components/tables.py
+++ b/circuitron/ui/components/tables.py
@@ -13,19 +13,15 @@ from ...models import SelectedPart, FoundPart
 
 
 def show_found_parts(console: Console, parts: dict[str, list[FoundPart]], theme: Theme) -> None:
-    """Render table of found components."""
+    """Render a unified table of found components."""
+    table = Table(title="Found Components", border_style=theme.accent, box=box.SIMPLE)
+    table.add_column("Query", style=theme.accent)
+    table.add_column("Name")
+    table.add_column("Library")
     for query, plist in parts.items():
-        table = Table(
-            title=f"Results for {query}",
-            border_style=theme.accent,
-            box=box.SIMPLE,
-            expand=False,
-        )
-        table.add_column("Name", style=theme.accent)
-        table.add_column("Library")
         for part in plist:
-            table.add_row(part.name, part.library)
-        console.print(table)
+            table.add_row(query, part.name, part.library)
+    console.print(table)
 
 
 def show_selected_parts(console: Console, parts: Iterable[SelectedPart], theme: Theme) -> None:

--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -155,9 +155,7 @@ def collect_user_feedback(
     This function prompts the user to answer open questions and request edits.
     """
     console = console or Console()
-    console.print("\n" + "=" * 60)
-    console.print("PLAN REVIEW & FEEDBACK")
-    console.print("=" * 60)
+    console.print(Panel("PLAN REVIEW & FEEDBACK", border_style="cyan"))
 
     feedback = UserFeedback()
     input_func = input_func or input
@@ -165,20 +163,20 @@ def collect_user_feedback(
     # Handle open questions if they exist
     if plan.design_limitations:
         console.print(
-            f"\nThe planner has identified {len(plan.design_limitations)} open questions that need your input:"
+            Panel(
+                f"The planner has identified {len(plan.design_limitations)} open questions that need your input:",
+                border_style="cyan",
+            )
         )
-        console.print("-" * 50)
 
         for i, question in enumerate(plan.design_limitations, 1):
-            console.print(f"\n{i}. {question}")
-            answer = sanitize_text(input_func("   Your answer: ").strip())
+            console.print(Panel(f"{i}. {question}", border_style="cyan"))
+            answer = sanitize_text(input_func("Answer: ").strip())
             if answer:
                 feedback.open_question_answers.append(f"Q{i}: {question}\nA: {answer}")
 
     # Collect general edits and modifications
-    console.print("\n" + "-" * 50)
-    console.print("OPTIONAL EDITS & MODIFICATIONS")
-    console.print("-" * 50)
+    console.print(Panel("OPTIONAL EDITS & MODIFICATIONS", border_style="cyan"))
     console.print(
         "Do you have any specific changes, clarifications, or modifications to request?"
     )
@@ -193,9 +191,7 @@ def collect_user_feedback(
         edit_counter += 1
 
     # Collect additional requirements
-    console.print("\n" + "-" * 50)
-    console.print("ADDITIONAL REQUIREMENTS")
-    console.print("-" * 50)
+    console.print(Panel("ADDITIONAL REQUIREMENTS", border_style="cyan"))
     console.print(
         "Are there any new requirements or constraints not captured in the original design?"
     )
@@ -483,9 +479,7 @@ def format_plan_summary(plan: PlanOutput | None) -> str:
         lines.extend(f"- {blk}" for blk in plan.functional_blocks)
     if plan.implementation_actions:
         lines.append("Implementation Steps:")
-        lines.extend(
-            f"{idx + 1}. {step}" for idx, step in enumerate(plan.implementation_actions)
-        )
+        lines.extend(f"- {step}" for step in plan.implementation_actions)
     if plan.implementation_notes:
         lines.append("Implementation Notes:")
         lines.extend(f"- {note}" for note in plan.implementation_notes)


### PR DESCRIPTION
## Summary
- drop emoji icons from CLI messages
- use colored prompt_toolkit input instead of panel in `InputBox`
- consolidate found parts into a single table
- show plan feedback prompts inside panels
- fix duplicated numbering in plan summary
- centralize more pipeline output through `TerminalUI`

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740058fffc8333ab718fae38af9fff