### PR TITLE
Improve CLI prompt and spinners

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -66,7 +66,7 @@ def main() -> None:
         return
 
     ui.start_banner()
-    prompt = args.prompt or ui.prompt_user("Prompt")
+    prompt = args.prompt or ui.prompt_user("What would you like me to design?")
     show_reasoning = args.reasoning
     retries = args.retries
     output_dir = args.output_dir

--- a/circuitron/ui/app.py
+++ b/circuitron/ui/app.py
@@ -118,6 +118,10 @@ class TerminalUI:
             title="Generated SKiDL Code",
         )
 
+    def display_validation_summary(self, summary: str) -> None:
+        """Show code validation results in a panel."""
+        panel.show_panel(self.console, "Validation", summary, self.theme)
+
     def display_generated_files_summary(self, files: Iterable[str]) -> None:
         links = "\n".join(f"[link=file://{p}]{p}[/]" for p in files)
         MessagePanel.info(self.console, links, self.theme)

--- a/circuitron/ui/components/input_box.py
+++ b/circuitron/ui/components/input_box.py
@@ -17,7 +17,7 @@ class InputBox:
 
     def ask(self, message: str) -> str:
         """Return user input for ``message`` using prompt_toolkit."""
-        prompt_text = f"[{self.theme.accent}]{message}:[/] "
+        prompt_text = f"[{self.theme.accent}]{message}[/] "
         try:
             return self.session.prompt(prompt_text)
         except Exception:


### PR DESCRIPTION
## Summary
- tweak input label text and remove prompt prefix
- display validation summaries via TerminalUI
- fix spinner visibility by passing UI through pipeline
- quiet noisy Docker warnings

## Testing
- `pytest -q`
- `ruff check .`
- `mypy --strict circuitron` *(fails: unused ignore comments in prompt/input_box)*

------
https://chatgpt.com/codex/tasks/task_e_68740dcec5a0833386c471d75e3a1469