### PR TITLE
Omit footprints when search disabled

### DIFF
--- a/circuitron/utils.py
+++ b/circuitron/utils.py
@@ -356,7 +356,7 @@ def format_part_selection_input(plan: PlanOutput, found: PartFinderOutput) -> st
 
     import json
 
-    found_json = json.dumps(found.model_dump())
+    found_json = json.dumps(found.model_dump(exclude_none=True))
     parts.extend(["PART SEARCH RESULTS JSON:", found_json, ""])
     parts.append("Select the best components and extract pin details.")
     return "\n".join(parts)
@@ -437,9 +437,14 @@ def pretty_print_selected_parts(selection: PartSelectionOutput) -> None:
         print("\nNo parts selected.")
         return
 
+    from .config import settings
+
     print("\n=== SELECTED COMPONENTS ===")
     for part in selection.selections:
-        print(f"\n{part.name} ({part.library}) -> {part.footprint}")
+        headline = f"\n{part.name} ({part.library})"
+        if settings.footprint_search_enabled and part.footprint:
+            headline += f" -> {part.footprint}"
+        print(headline)
         if part.selection_reason:
             print(f"Reason: {part.selection_reason}")
         if part.pin_details:
@@ -504,10 +509,12 @@ def format_selection_summary(selection: PartSelectionOutput | None) -> str:
     if selection is None:
         return ""
 
+    from .config import settings
+
     lines: list[str] = []
     for part in selection.selections:
         headline = f"- {part.name} ({part.library})"
-        if part.footprint:
+        if settings.footprint_search_enabled and part.footprint:
             headline += f" -> {part.footprint}"
         lines.append(headline)
         for pin in part.pin_details:
@@ -564,10 +571,15 @@ def format_code_generation_input(
                 "",
             ]
         )
+    from .config import settings
+
     if selection.selections:
         parts.append("Selected Components:")
         for part in selection.selections:
-            parts.append(f"- {part.name} ({part.library}) -> {part.footprint}")
+            line = f"- {part.name} ({part.library})"
+            if settings.footprint_search_enabled and part.footprint:
+                line += f" -> {part.footprint}"
+            parts.append(line)
             for pin in part.pin_details:
                 parts.append(f"  pin {pin.number}: {pin.name} / {pin.function}")
         parts.append("")
@@ -591,10 +603,15 @@ def format_code_validation_input(
         script_content,
         "",
     ]
+    from .config import settings
+
     if selection.selections:
         parts.append("Selected Components:")
         for part in selection.selections:
-            parts.append(f"- {part.name} ({part.library}) -> {part.footprint}")
+            line = f"- {part.name} ({part.library})"
+            if settings.footprint_search_enabled and part.footprint:
+                line += f" -> {part.footprint}"
+            parts.append(line)
             for pin in part.pin_details:
                 parts.append(f"  pin {pin.number}: {pin.name}")
         parts.append("")

--- a/tests/test_format_input.py
+++ b/tests/test_format_input.py
@@ -12,6 +12,7 @@ from circuitron.utils import (
     format_plan_edit_input,
     format_documentation_input,
     format_code_generation_input,
+    format_code_validation_input,
     format_erc_handling_input,
 )
 
@@ -60,6 +61,28 @@ def test_format_code_generation_input_includes_docs() -> None:
     text = format_code_generation_input(plan, selection, docs)
     assert "CODE GENERATION CONTEXT" in text
     assert "example" in text
+
+
+def test_format_inputs_omit_footprints_when_disabled() -> None:
+    import circuitron.config as cfg
+
+    cfg.setup_environment()
+    cfg.settings.footprint_search_enabled = False
+
+    plan = PlanOutput()
+    pin = PinDetail(number="1", name="VCC", function="POWER-IN")
+    part = SelectedPart(name="U1", library="lib", footprint="SOIC", pin_details=[pin])
+    selection = PartSelectionOutput(selections=[part])
+    docs = DocumentationOutput(
+        research_queries=[],
+        documentation_findings=["doc"],
+        implementation_readiness="ok",
+    )
+    gen_text = format_code_generation_input(plan, selection, docs)
+    val_text = format_code_validation_input("print()", selection, docs)
+
+    assert "SOIC" not in gen_text
+    assert "SOIC" not in val_text
 
 
 def test_format_erc_handling_input_provides_history() -> None:


### PR DESCRIPTION
## Summary
- skip empty footprint fields in part selection input
- gate footprint output on settings in utilities
- test footprint flag behavior

## Testing
- `ruff check .`
- `mypy circuitron`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687414f7577483338a6a3b438bec956d