### PR TITLE
Add no-footprint prompt variants

### DIFF
--- a/circuitron/agents.py
+++ b/circuitron/agents.py
@@ -20,8 +20,10 @@ from .prompts import (
     PARTFINDER_PROMPT,
     PARTFINDER_PROMPT_NO_FOOTPRINT,
     PART_SELECTION_PROMPT,
+    PART_SELECTION_PROMPT_NO_FOOTPRINT,
     DOC_AGENT_PROMPT,
     CODE_GENERATION_PROMPT,
+    CODE_GENERATION_PROMPT_NO_FOOTPRINT,
     CODE_VALIDATION_PROMPT,
     CODE_CORRECTION_PROMPT,
     ERC_HANDLING_PROMPT,
@@ -125,9 +127,14 @@ def create_partselection_agent() -> Agent:
 
     tools: list[Tool] = [extract_pin_details]
 
+    prompt = (
+        PART_SELECTION_PROMPT
+        if settings.footprint_search_enabled
+        else PART_SELECTION_PROMPT_NO_FOOTPRINT
+    )
     return Agent(
         name="Circuitron-PartSelector",
-        instructions=PART_SELECTION_PROMPT,
+        instructions=prompt,
         model=settings.part_selection_model,
         output_type=PartSelectionOutput,
         tools=tools,
@@ -157,9 +164,14 @@ def create_code_generation_agent() -> Agent:
         tool_choice=_tool_choice_for_mcp(settings.code_generation_model)
     )
 
+    prompt = (
+        CODE_GENERATION_PROMPT
+        if settings.footprint_search_enabled
+        else CODE_GENERATION_PROMPT_NO_FOOTPRINT
+    )
     return Agent(
         name="Circuitron-Coder",
-        instructions=CODE_GENERATION_PROMPT,
+        instructions=prompt,
         model=settings.code_generation_model,
         output_type=CodeGenerationOutput,
         mcp_servers=[mcp_manager.get_server()],

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -52,6 +52,34 @@ def test_partfinder_disables_footprint_tool() -> None:
     assert agent.instructions == prompts.PARTFINDER_PROMPT_NO_FOOTPRINT
 
 
+def test_partselector_prompt_no_footprint() -> None:
+    import sys
+
+    sys.modules.pop("circuitron.agents", None)
+    import circuitron.config as cfg
+
+    cfg.setup_environment()
+    cfg.settings.footprint_search_enabled = False
+    mod = importlib.import_module("circuitron.agents")
+    agent = mod.get_partselection_agent()
+    from circuitron import prompts
+    assert agent.instructions == prompts.PART_SELECTION_PROMPT_NO_FOOTPRINT
+
+
+def test_code_generation_prompt_no_footprint() -> None:
+    import sys
+
+    sys.modules.pop("circuitron.agents", None)
+    import circuitron.config as cfg
+
+    cfg.setup_environment()
+    cfg.settings.footprint_search_enabled = False
+    mod = importlib.import_module("circuitron.agents")
+    agent = mod.get_code_generation_agent()
+    from circuitron import prompts
+    assert agent.instructions == prompts.CODE_GENERATION_PROMPT_NO_FOOTPRINT
+
+
 def test_partselector_includes_pin_tool() -> None:
     import sys
 


### PR DESCRIPTION
## Summary
- add PART_SELECTION_PROMPT_NO_FOOTPRINT and CODE_GENERATION_PROMPT_NO_FOOTPRINT
- switch agents to use the new prompts when `footprint_search_enabled` is disabled
- test that prompt variants are selected when footprint search is off
- include SKiDL docs snippet on handling empty footprints in CODE_GENERATION_PROMPT_NO_FOOTPRINT

## Testing
- `ruff check .`
- `pytest -q`
- `mypy --strict circuitron` *(fails: unused type ignore comments)*

------
https://chatgpt.com/codex/tasks/task_e_687414f5bb58833389a732c35c4cd321