### PR TITLE
Fix InputBox prompt coloring

### DIFF
--- a/circuitron/ui/components/input_box.py
+++ b/circuitron/ui/components/input_box.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from rich.console import Console
 from prompt_toolkit import PromptSession  # type: ignore
 from prompt_toolkit.history import InMemoryHistory  # type: ignore
+from prompt_toolkit.formatted_text import HTML  # type: ignore
 
 from ..themes import Theme
 
@@ -17,7 +18,7 @@ class InputBox:
 
     def ask(self, message: str) -> str:
         """Return user input for ``message`` using prompt_toolkit."""
-        prompt_text = f"[{self.theme.accent}]{message}[/] "
+        prompt_text = HTML(f'<style fg="{self.theme.accent}">{message}</style> ')
         try:
             return self.session.prompt(prompt_text)
         except Exception:

--- a/tests/test_input_box.py
+++ b/tests/test_input_box.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock
+
+from rich.console import Console
+from prompt_toolkit.formatted_text import HTML  # type: ignore
+
+from circuitron.ui.components.input_box import InputBox
+from circuitron.ui.themes import Theme
+
+
+def test_input_box_ask_uses_html(monkeypatch):
+    session = MagicMock()
+    monkeypatch.setattr(
+        "circuitron.ui.components.input_box.PromptSession", lambda *a, **k: session
+    )
+    ib = InputBox(Console(), Theme(name="t", gradient_colors=[], accent="green"))
+    session.prompt.return_value = "done"
+    result = ib.ask("hello")
+    assert result == "done"
+    args = session.prompt.call_args[0][0]
+    assert isinstance(args, HTML)
+    assert "hello" in str(args)
+


### PR DESCRIPTION
## Summary
- color InputBox prompt using `prompt_toolkit.formatted_text.HTML`
- add regression test for InputBox.ask

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: unused ignore comments and missing type annotations)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742207dc0c8333b95842c9d7cc06e1