### PR TITLE
Log codegen validation warnings and refine pipeline docs

### DIFF
--- a/circuitron/ui/components/input_box.py
+++ b/circuitron/ui/components/input_box.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from rich.console import Console
-from prompt_toolkit import PromptSession  # type: ignore
-from prompt_toolkit.history import InMemoryHistory  # type: ignore
-from prompt_toolkit.formatted_text import HTML  # type: ignore
+from prompt_toolkit import PromptSession
+from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.formatted_text import HTML
+from typing import Any, cast
 
 from ..themes import Theme
 
@@ -14,12 +15,12 @@ class InputBox:
     def __init__(self, console: Console, theme: Theme) -> None:
         self.console = console
         self.theme = theme
-        self.session: PromptSession = PromptSession(history=InMemoryHistory())
+        self.session: PromptSession[Any] = PromptSession(history=InMemoryHistory())
 
     def ask(self, message: str) -> str:
         """Return user input for ``message`` using prompt_toolkit."""
         prompt_text = HTML(f'<style fg="{self.theme.accent}">{message}</style> ')
         try:
-            return self.session.prompt(prompt_text)
+            return cast(str, self.session.prompt(prompt_text))
         except Exception:
             return input(f"{message}: ")

--- a/circuitron/ui/components/prompt.py
+++ b/circuitron/ui/components/prompt.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from prompt_toolkit import PromptSession  # type: ignore
-from prompt_toolkit.history import FileHistory  # type: ignore
-from prompt_toolkit.key_binding import KeyBindings  # type: ignore
-from prompt_toolkit.formatted_text import HTML  # type: ignore
+from prompt_toolkit import PromptSession
+from prompt_toolkit.history import FileHistory
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.formatted_text import HTML
 from rich.console import Console
+from typing import Any, cast
 
 from ..themes import Theme
 
@@ -24,7 +25,7 @@ class Prompt:
         bindings.add("c-a")(lambda event: event.current_buffer.cursor_home())
         bindings.add("c-e")(lambda event: event.current_buffer.cursor_end())
         bindings.add("c-l")(lambda event: event.app.renderer.clear())
-        self.session: PromptSession = PromptSession(
+        self.session: PromptSession[Any] = PromptSession(
             history=FileHistory(str(history_file)), key_bindings=bindings
         )
 
@@ -32,6 +33,6 @@ class Prompt:
         """Return user input for ``message``."""
         prompt_text = HTML(f'<style fg="{self.theme.accent}">{message}:</style> ')
         try:
-            return self.session.prompt(prompt_text)
+            return cast(str, self.session.prompt(prompt_text))
         except Exception:
             return input(f"{message}: ")

--- a/tests/test_code_generation_warning.py
+++ b/tests/test_code_generation_warning.py
@@ -1,0 +1,29 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import circuitron.pipeline as pl
+from circuitron.models import (
+    PlanOutput,
+    PartSelectionOutput,
+    DocumentationOutput,
+    CodeGenerationOutput,
+)
+
+
+def test_run_code_generation_logs_warning() -> None:
+    async def run() -> None:
+        plan = PlanOutput()
+        selection = PartSelectionOutput()
+        docs = DocumentationOutput(
+            research_queries=[], documentation_findings=[], implementation_readiness="ok"
+        )
+        code_out = CodeGenerationOutput(complete_skidl_code="code")
+        sink = SimpleNamespace(warning=MagicMock())
+        with patch("circuitron.pipeline.format_code_generation_input", return_value="x"), \
+             patch("circuitron.debug.Runner.run", AsyncMock(return_value=SimpleNamespace(final_output=code_out))), \
+             patch("circuitron.pipeline.pretty_print_generated_code"), \
+             patch("circuitron.pipeline.validate_code_generation_results", return_value=False):
+            await pl.run_code_generation(plan, selection, docs, sink=sink)
+        sink.warning.assert_called_once()
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Document `sink` support and optional `feedback_provider` in `pipeline` docstring
- Warn via progress sink when basic code-generation validation fails
- Add regression test for progress sink warning path
- Tighten type hints for `PromptSession` helpers and adjust retry logic for mypy compliance

## Testing
- `ruff check`
- `mypy --strict circuitron/pipeline.py circuitron/ui/components/input_box.py circuitron/ui/components/prompt.py tests/test_code_generation_warning.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68962cafb7bc833398b873b4e85bfb62