### PR TITLE
Improve pipeline docstrings and add codegen warning test

### DIFF
--- a/circuitron/network.py
+++ b/circuitron/network.py
@@ -38,4 +38,4 @@ def check_internet_connection() -> bool:
     """
     return is_connected()
 
-__all__ = ["check_internet_connection", "is_connected"]
+__all__ = ["check_internet_connection", "is_connected", "httpx"]

--- a/circuitron/ui/components/input_box.py
+++ b/circuitron/ui/components/input_box.py
@@ -4,6 +4,7 @@ from rich.console import Console
 from prompt_toolkit import PromptSession  # type: ignore
 from prompt_toolkit.history import InMemoryHistory  # type: ignore
 from prompt_toolkit.formatted_text import HTML  # type: ignore
+from typing import cast
 
 from ..themes import Theme
 
@@ -25,7 +26,7 @@ class InputBox:
         prompt_text = HTML(f'<style fg="{self.theme.accent}">{message}</style> ')
         if self.session is not None:
             try:
-                return self.session.prompt(prompt_text)
+                return cast(str, self.session.prompt(prompt_text))
             except Exception:
                 pass
         return input(f"{message}: ")

--- a/circuitron/ui/components/prompt.py
+++ b/circuitron/ui/components/prompt.py
@@ -9,6 +9,7 @@ from prompt_toolkit.history import FileHistory  # type: ignore
 from prompt_toolkit.key_binding import KeyBindings  # type: ignore
 from prompt_toolkit.formatted_text import HTML  # type: ignore
 from rich.console import Console
+from typing import cast
 
 from ..themes import Theme
 
@@ -40,7 +41,7 @@ class Prompt:
         prompt_text = HTML(f'<style fg="{self.theme.accent}">{message}:</style> ')
         if self.session is not None:
             try:
-                return self.session.prompt(prompt_text)
+                return cast(str, self.session.prompt(prompt_text))
             except Exception:
                 pass
         return input(f"{message}: ")

--- a/tests/test_codegen_warning.py
+++ b/tests/test_codegen_warning.py
@@ -1,0 +1,36 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import circuitron.pipeline as pl
+from circuitron.models import PlanOutput, PartSelectionOutput, DocumentationOutput, CodeGenerationOutput
+from circuitron.progress import NullProgressSink
+
+
+class WarningSink(NullProgressSink):
+    def __init__(self) -> None:
+        super().__init__()
+        self.warnings: list[str] = []
+
+    def display_warning(self, message: str) -> None:
+        self.warnings.append(message)
+
+
+async def _run_codegen_with_warning() -> WarningSink:
+    sink = WarningSink()
+    with patch("circuitron.pipeline.run_agent", AsyncMock(return_value=SimpleNamespace(final_output=CodeGenerationOutput(complete_skidl_code="code")))), \
+         patch("circuitron.pipeline.validate_code_generation_results", return_value=False):
+        await pl.run_code_generation(
+            PlanOutput(),
+            PartSelectionOutput(),
+            DocumentationOutput(research_queries=[], documentation_findings=[], implementation_readiness="ok"),
+            sink=sink,
+        )
+    return sink
+
+
+def test_run_code_generation_warns() -> None:
+    sink = asyncio.run(_run_codegen_with_warning())
+    assert any(
+        "Basic code checks failed" in msg for msg in sink.warnings
+    )

--- a/tests/test_input_box.py
+++ b/tests/test_input_box.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+import pytest
 from rich.console import Console
 from prompt_toolkit.formatted_text import HTML  # type: ignore
 
@@ -7,7 +8,7 @@ from circuitron.ui.components.input_box import InputBox
 from circuitron.ui.themes import Theme
 
 
-def test_input_box_ask_uses_html(monkeypatch):
+def test_input_box_ask_uses_html(monkeypatch: pytest.MonkeyPatch) -> None:
     session = MagicMock()
     monkeypatch.setattr(
         "circuitron.ui.components.input_box.PromptSession", lambda *a, **k: session


### PR DESCRIPTION
## Summary
- clarify pipeline and helper docstrings, including sink parameter details and properly indented arguments
- warn progress sink when basic code validation fails and add regression test
- ensure type safety in UI components and expose httpx for network testing

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68963383f1648333b5aa601643837da7