### PR TITLE
feat: graceful exit on Esc and friendly interrupt handling

### DIFF
--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -38,6 +38,12 @@ async def run_circuitron(
             else:
                 ui.display_error(f"Fatal error: {exc}")
             return None
+    except (KeyboardInterrupt, EOFError):
+        if ui is None:
+            print("\nGoodbye! Thanks for using Circuitron.")
+        else:
+            ui.console.print("\nGoodbye! Thanks for using Circuitron.", style="yellow")
+        return None
     finally:
         await mcp_manager.cleanup()
 
@@ -74,7 +80,12 @@ def main() -> None:
         return
 
     ui.start_banner()
-    prompt = args.prompt or ui.prompt_user("What would you like me to design?")
+    try:
+        prompt = args.prompt or ui.prompt_user("What would you like me to design?")
+    except (KeyboardInterrupt, EOFError):
+        ui.console.print("\nGoodbye! Thanks for using Circuitron.", style="yellow")
+        kicad_session.stop()
+        return
     show_reasoning = args.reasoning
     retries = args.retries
     output_dir = args.output_dir
@@ -84,10 +95,16 @@ def main() -> None:
     try:
         try:
             code_output = asyncio.run(
-                ui.run(prompt, show_reasoning=show_reasoning, retries=retries, output_dir=output_dir, keep_skidl=keep_skidl)
+                ui.run(
+                    prompt,
+                    show_reasoning=show_reasoning,
+                    retries=retries,
+                    output_dir=output_dir,
+                    keep_skidl=keep_skidl,
+                )
             )
-        except KeyboardInterrupt:
-            ui.console.print("\nExecution interrupted by user.", style="red")
+        except (KeyboardInterrupt, EOFError):
+            ui.console.print("\nGoodbye! Thanks for using Circuitron.", style="yellow")
         except Exception as exc:
             ui.console.print(f"Error during execution: {exc}", style="red")
     finally:

--- a/circuitron/ui/app.py
+++ b/circuitron/ui/app.py
@@ -40,7 +40,10 @@ class TerminalUI:
     def start_banner(self) -> None:
         """Render the Circuitron banner with gradient colors."""
         self.banner.show()
-        self.console.print("[bold]Type /help for commands[/bold]\n", style=ACCENT)
+        self.console.print(
+            "[bold]Type /help for commands or press Esc to exit[/bold]\n",
+            style=ACCENT,
+        )
 
     def start_stage(self, name: str) -> None:
         self.status_bar.update(stage=name, message="")

--- a/circuitron/ui/components/prompt.py
+++ b/circuitron/ui/components/prompt.py
@@ -24,9 +24,14 @@ class Prompt:
         self._bindings.add("c-a")(lambda event: event.current_buffer.cursor_home())
         self._bindings.add("c-e")(lambda event: event.current_buffer.cursor_end())
         self._bindings.add("c-l")(lambda event: event.app.renderer.clear())
+        self._bindings.add("escape")(lambda event: event.app.exit(exception=EOFError()))
 
     def ask(self, message: str) -> str:
-        """Return user input for ``message``."""
+        """Return user input for ``message``.
+
+        Pressing ``Esc`` exits the application.
+        """
+        message = f"{message} (press Esc to exit)"
         prompt_text = HTML(f'<style fg="{ACCENT}">{message}:</style> ')
         # Lazily create the PromptSession to avoid failures on headless Windows tests
         if self._session is None:
@@ -42,4 +47,7 @@ class Prompt:
                 raise RuntimeError("No interactive session available")
             return self._session.prompt(prompt_text)
         except Exception:
-            return input(f"{message}: ")
+            text = input(f"{message}: ")
+            if text == "\x1b":
+                raise EOFError
+            return text

--- a/collab_progress/CHANGELOG.md
+++ b/collab_progress/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Circuitron Changelog (collab_progress index)
 
+## Graceful exit via Esc and friendly Ctrl+C
+- Date: 2025-08-11
+- Time (UTC): 00:00Z
+- Branch/PR: main
+- Files Changed (high level): cli, ui components, tests
+- Details: See collab_progress/graceful-exit-esc-11-08-2025.md
+- Verification: pytest -q; ruff check .; mypy --strict circuitron (fails: unused type ignores and missing annotations)
+
 ## UI/UX: Human-friendly ERC result display (Issue #5)
 - Date: 2025-08-10
 - Time (UTC): 00:00Z

--- a/collab_progress/graceful-exit-esc-11-08-2025.md
+++ b/collab_progress/graceful-exit-esc-11-08-2025.md
@@ -1,0 +1,30 @@
+# Graceful exit with Esc key and friendly Ctrl+C handling
+
+## Summary
+- Allow exiting at any prompt by pressing `Esc`.
+- Catch `KeyboardInterrupt` and display a friendly goodbye message.
+- Informed users about `Esc` usage in UI banner and prompts.
+
+## Files Changed
+- `circuitron/cli.py`
+- `circuitron/ui/app.py`
+- `circuitron/ui/components/input_box.py`
+- `circuitron/ui/components/prompt.py`
+- `tests/test_cli.py`
+- `tests/test_feedback_ui.py`
+- `tests/test_input_box.py`
+- `tests/test_model_switch.py`
+
+## Rationale
+Improve usability by offering an intuitive exit mechanism and clearer messaging when terminating the program.
+
+## Verification
+- `pytest -q`
+- `ruff check .`
+- `mypy --strict circuitron` *(fails: Unused type ignores and missing annotations)*
+
+## Issues
+- Existing mypy errors remain; repository not fully type-safe.
+
+## Next Steps
+- Address outstanding mypy errors across UI components.

--- a/tests/test_feedback_ui.py
+++ b/tests/test_feedback_ui.py
@@ -80,7 +80,8 @@ def test_pipeline_uses_ui_collect_feedback() -> None:
              patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
              patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
              patch.object(pl, "run_code_validation", AsyncMock(side_effect=[val_pass_no_erc, val_pass_no_erc, val_pass_no_erc])), \
-             patch.object(pl, "collect_user_feedback", side_effect=AssertionError("collect_user_feedback should not be called when UI is provided")):
+             patch.object(pl, "collect_user_feedback", side_effect=AssertionError("collect_user_feedback should not be called when UI is provided")), \
+             patch.object(pl, "execute_final_script", AsyncMock(return_value="[]")):
             return await pl.pipeline("test", ui=ui)
 
     result = asyncio.run(_run())

--- a/tests/test_input_box.py
+++ b/tests/test_input_box.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import asyncio
+import pytest
 from rich.console import Console
 from prompt_toolkit.formatted_text import HTML  # type: ignore
 
@@ -34,4 +36,13 @@ def test_input_box_ask_renders_box(monkeypatch):
     assert "┌" in text
     assert "└" in text
     assert "Design?" in text
+
+
+def test_input_box_escape(monkeypatch):
+    ib = InputBox(Console())
+    monkeypatch.setattr("builtins.input", lambda _p: "\x1b")
+    async def run() -> None:
+        with pytest.raises(EOFError):
+            ib.ask("msg")
+    asyncio.run(run())
 

--- a/tests/test_model_switch.py
+++ b/tests/test_model_switch.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import importlib
 import pytest
 


### PR DESCRIPTION
## Summary
- allow quitting Circuitron with Esc at any prompt
- display a friendly goodbye message on Esc or Ctrl+C
- inform users about Esc shortcut in banner and prompts

## Testing
- `pytest -q`
- `ruff check .`
- `mypy --strict circuitron` *(fails: unused type ignores and missing annotations)*

------
https://chatgpt.com/codex/tasks/task_e_6897c3a8a69c8333ab87157a8654f677