### PR TITLE
Handle termination signals in CLI

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import signal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -212,3 +213,14 @@ def test_cli_dev_mode_shows_run_items(capsys: pytest.CaptureFixture[str]) -> Non
     captured = capsys.readouterr().out
     cfg.settings.dev_mode = False
     assert "hello" in captured
+
+
+@pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM])
+def test_signal_handlers_stop_session(sig: signal.Signals) -> None:
+    """Signal handlers should stop the KiCad session before exiting."""
+    with patch("circuitron.tools.kicad_session.stop") as stop_mock, \
+         patch("circuitron.cli.sys.exit", side_effect=SystemExit) as exit_mock:
+        with pytest.raises(SystemExit):
+            signal.raise_signal(sig)
+    stop_mock.assert_called_once()
+    exit_mock.assert_called_once()

--- a/tests/test_feedback_ui.py
+++ b/tests/test_feedback_ui.py
@@ -80,7 +80,8 @@ def test_pipeline_uses_ui_collect_feedback() -> None:
              patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
              patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
              patch.object(pl, "run_code_validation", AsyncMock(side_effect=[val_pass_no_erc, val_pass_no_erc, val_pass_no_erc])), \
-             patch.object(pl, "collect_user_feedback", side_effect=AssertionError("collect_user_feedback should not be called when UI is provided")):
+             patch.object(pl, "collect_user_feedback", side_effect=AssertionError("collect_user_feedback should not be called when UI is provided")), \
+             patch.object(pl, "execute_final_script", AsyncMock(return_value="{}")):
             return await pl.pipeline("test", ui=ui)
 
     result = asyncio.run(_run())

--- a/tests/test_feedback_ui.py
+++ b/tests/test_feedback_ui.py
@@ -78,10 +78,10 @@ def test_pipeline_uses_ui_collect_feedback() -> None:
              patch.object(pl, "run_part_finder", AsyncMock(return_value=part_out)), \
              patch.object(pl, "run_part_selector", AsyncMock(return_value=select_out)), \
              patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
-             patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
-             patch.object(pl, "run_code_validation", AsyncMock(side_effect=[val_pass_no_erc, val_pass_no_erc, val_pass_no_erc])), \
-             patch.object(pl, "collect_user_feedback", side_effect=AssertionError("collect_user_feedback should not be called when UI is provided")), \
-             patch.object(pl, "execute_final_script", AsyncMock(return_value="{}")):
+            patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
+            patch.object(pl, "run_code_validation", AsyncMock(return_value=val_pass_no_erc)), \
+            patch.object(pl, "collect_user_feedback", side_effect=AssertionError("collect_user_feedback should not be called when UI is provided")), \
+            patch.object(pl, "execute_final_script", AsyncMock(return_value="{}")):
             return await pl.pipeline("test", ui=ui)
 
     result = asyncio.run(_run())

--- a/tests/test_model_switch.py
+++ b/tests/test_model_switch.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import importlib
 import pytest
 


### PR DESCRIPTION
## Summary
- stop KiCad Docker session when SIGINT or SIGTERM is received
- document signal cleanup handler and rely on `atexit` as fallback
- test signal handlers and patch feedback pipeline test to avoid docker dependency

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: 43 errors in unrelated modules)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c53efce88333a8fef2c863ce4748