### PR TITLE
Force-remove stale Docker containers by prefix

### DIFF
--- a/tests/test_cleanup_stale_containers.py
+++ b/tests/test_cleanup_stale_containers.py
@@ -1,0 +1,16 @@
+import subprocess
+from unittest.mock import patch
+
+from circuitron.docker_session import cleanup_stale_containers
+
+
+def test_cleanup_stale_containers_force_removes_running() -> None:
+    ps_proc = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="abc cont1\ndef cont2\n", stderr=""
+    )
+    rm_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with patch("subprocess.run", side_effect=[ps_proc, rm_proc]) as run_mock:
+        cleanup_stale_containers("cont", "cont2")
+    assert run_mock.call_args_list[0].args[0][:3] == ["docker", "ps", "-a"]
+    assert run_mock.call_args_list[1].args[0][:3] == ["docker", "rm", "-f"]
+    assert run_mock.call_args_list[1].args[0][3:] == ["abc"]

--- a/tests/test_feedback_ui.py
+++ b/tests/test_feedback_ui.py
@@ -80,7 +80,8 @@ def test_pipeline_uses_ui_collect_feedback() -> None:
              patch.object(pl, "run_documentation", AsyncMock(return_value=doc_out)), \
              patch.object(pl, "run_code_generation", AsyncMock(return_value=code_out)), \
              patch.object(pl, "run_code_validation", AsyncMock(side_effect=[val_pass_no_erc, val_pass_no_erc, val_pass_no_erc])), \
-             patch.object(pl, "collect_user_feedback", side_effect=AssertionError("collect_user_feedback should not be called when UI is provided")):
+             patch.object(pl, "collect_user_feedback", side_effect=AssertionError("collect_user_feedback should not be called when UI is provided")), \
+             patch.object(pl, "execute_final_script", AsyncMock(return_value="{\"success\": true, \"files\": []}")):
             return await pl.pipeline("test", ui=ui)
 
     result = asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Replace `cleanup_stale_containers` to remove all containers matching the given prefix, including running ones
- Exclude the current container name when cleaning
- Add unit tests confirming running containers are force-removed
- Patch feedback UI test to mock final script execution and avoid Docker calls

## Testing
- `ruff check circuitron/docker_session.py tests/test_cleanup_stale_containers.py tests/test_feedback_ui.py`
- `mypy --strict --no-error-summary circuitron/docker_session.py tests/test_cleanup_stale_containers.py` *(fails: missing type hints in unrelated UI modules)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c53dcbe48333ba3010bf09b26587