### PR TITLE
docs: add cleanup command for kicad containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,16 @@ Update these variables in your environment or in the `.env` file to customise be
 - **KiCad container fails to start** – pull the image again with `docker pull ghcr.io/shaurya-sethi/circuitron-kicad:latest` and verify Docker is running.
 - **Missing environment variables** – the CLI exits with an error if `OPENAI_API_KEY` or `MCP_URL` are not set. Check your `.env` configuration.
 
+## Cleanup
+
+KiCad containers started by Circuitron may keep running in the background. Remove leftover containers to free resources and avoid conflicts by running:
+
+```bash
+docker rm -f $(docker ps -aq -f name=circuitron-kicad-)
+```
+
+Run this after testing or whenever you need to reset the Circuitron KiCad environment.
+
 ## Support and Contributing
 
 Contributions are welcome. Please open issues or pull requests on the repository if you encounter problems or have suggestions. Refer to `AGENTS.md` for coding guidelines and `overview.md` for additional background on the architecture.

--- a/collab_progress/CHANGELOG.md
+++ b/collab_progress/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Circuitron Changelog (collab_progress index)
 
+## Docs: Cleanup command for KiCad containers
+- Date: 2025-08-09
+- Time (UTC): 22:46Z
+- Branch/PR: main
+- Files Changed (high level): README
+- Details: See collab_progress/docs-cleanup-section-09-08-2025.md
+- Verification: pytest -q
+
 ## Signal handlers stop KiCad session on termination
 - Date: 2025-08-09
 - Time (UTC): 22:40Z

--- a/collab_progress/docs-cleanup-section-09-08-2025.md
+++ b/collab_progress/docs-cleanup-section-09-08-2025.md
@@ -1,0 +1,19 @@
+# Docs: add Cleanup section for KiCad containers
+
+## Summary
+Added a Cleanup section to the README instructing users how to remove lingering Circuitron KiCad containers.
+
+## Files Changed
+- README.md
+
+## Rationale
+Provide users with guidance on clearing leftover Docker containers to free resources and avoid conflicts.
+
+## Verification
+- `pytest -q`
+
+## Issues
+- None
+
+## Next Steps
+- None


### PR DESCRIPTION
## Summary
- document how to remove lingering Circuitron KiCad containers
- record cleanup documentation in progress notes and changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897cf1a82d4833390d72e216215e6ba