### PR TITLE
chore: migrate to openai-agents 0.2.10

### DIFF
--- a/circuitron/cost_estimator.py
+++ b/circuitron/cost_estimator.py
@@ -25,7 +25,8 @@ If `_model_prices_local.py` is missing, estimations return 0 with a flag.
 
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from typing import Any, Dict, Mapping, Tuple
+import importlib
 import os
 import json
 
@@ -34,7 +35,7 @@ _PRICE_SOURCE = "none"
 
 # 1) Try local-only prices (not in git)
 try:
-    from . import _model_prices_local as prices_mod  # type: ignore
+    prices_mod = importlib.import_module("circuitron._model_prices_local")
     PRICES = getattr(prices_mod, "PRICES", {}) or {}
     if PRICES:
         _PRICE_SOURCE = "local_module"
@@ -60,7 +61,7 @@ if not PRICES:
 # 3) Fall back to built-in prices unless explicitly disabled
 if not PRICES and os.getenv("CIRCUITRON_DISABLE_BUILTIN_PRICES") not in ("1", "true", "True"):
     try:
-        from . import model_prices_builtin as builtin_prices  # type: ignore
+        from . import model_prices_builtin as builtin_prices
         PRICES = getattr(builtin_prices, "PRICES", {}) or {}
         if PRICES:
             _PRICE_SOURCE = "builtin"
@@ -68,7 +69,7 @@ if not PRICES and os.getenv("CIRCUITRON_DISABLE_BUILTIN_PRICES") not in ("1", "t
         PRICES = {}
 
 
-def estimate_cost_usd(token_summary: dict) -> Tuple[float, bool, dict]:
+def estimate_cost_usd(token_summary: Mapping[str, Any]) -> Tuple[float, bool, Dict[str, float]]:
     """Estimate USD cost for a token usage summary.
 
     Args:
@@ -110,7 +111,7 @@ def price_source() -> str:
 __all__ = ["estimate_cost_usd", "estimate_cost_usd_for_model", "price_source"]
 
 
-def estimate_cost_usd_for_model(token_summary: dict, model: str) -> Tuple[float, bool]:
+def estimate_cost_usd_for_model(token_summary: Mapping[str, Any], model: str) -> Tuple[float, bool]:
     """Estimate USD cost assuming all tokens are billed to ``model``.
 
     This uses the overall token counts (input, output, cached_input) and applies

--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -268,13 +268,18 @@ async def run_code_validation(
         if run_erc_flag and validation.status == "pass" and script_path:
             erc_json = await run_erc(script_path)
             try:
-                erc_result = json.loads(erc_json)
+                erc_result = cast(dict[str, object], json.loads(erc_json))
             except (json.JSONDecodeError, TypeError) as e:
-                erc_result = {"success": False, "erc_passed": False, "stderr": f"JSON parsing error: {str(e)}", "stdout": erc_json}
+                erc_result = {
+                    "success": False,
+                    "erc_passed": False,
+                    "stderr": f"JSON parsing error: {str(e)}",
+                    "stdout": erc_json,
+                }
             if ui:
                 # Display a human-friendly summary instead of raw JSON
                 if hasattr(ui, "display_erc_result"):
-                    ui.display_erc_result(erc_result)  # type: ignore[arg-type]
+                    ui.display_erc_result(erc_result)
                 else:
                     panel.show_panel(ui.console, "ERC Result", json.dumps(erc_result, indent=2))
             else:
@@ -1008,7 +1013,10 @@ async def main() -> None:
             total_cost, used_default, _ = estimate_cost_usd(summary)
             if total_cost == 0.0:
                 from .config import settings as cfg
-                model_name = getattr(cfg, "code_generation_model", None) or getattr(cfg, "planning_model", "o4-mini")
+                model_name = str(
+                    getattr(cfg, "code_generation_model", None)
+                    or getattr(cfg, "planning_model", "o4-mini")
+                )
                 total_cost2, used_default2 = estimate_cost_usd_for_model(summary, model_name)
                 if total_cost2 > 0.0 or used_default:
                     total_cost, used_default = total_cost2, used_default2

--- a/circuitron/telemetry.py
+++ b/circuitron/telemetry.py
@@ -15,7 +15,7 @@ The aggregator is reset at the start of a run and summarized at the end.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, Optional
 import threading
 
@@ -116,7 +116,8 @@ except Exception:  # pragma: no cover - graceful degradation if OTEL missing
     SpanProcessor = object  # type: ignore
     TracerProvider = object  # type: ignore
     ReadableSpan = object  # type: ignore
-    get_tracer_provider = lambda: None  # type: ignore
+    def get_tracer_provider() -> object:  # type: ignore[explicit-ellipsis]
+        return None
 
 
 class TokenUsageSpanProcessor(SpanProcessor):

--- a/circuitron/tools.py
+++ b/circuitron/tools.py
@@ -595,11 +595,13 @@ async def execute_final_script(
 
     output_dir = prepare_output_dir(output_dir)
     # Determine container mount path for the host output directory. On Windows,
-    # map to /mnt/<drive>/<path>; otherwise fall back to a stable '/workspace'.
+    # map to ``/mnt/<drive>/<path>``. For Unix-style paths, default to the
+    # stable ``/workspace`` mount point rather than echoing the host path.
     try:
-        container_mount = convert_windows_path_for_docker(output_dir)
+        converted = convert_windows_path_for_docker(output_dir)
     except ValueError:
-        container_mount = "/workspace"
+        converted = output_dir
+    container_mount = converted if converted != output_dir else "/workspace"
 
     # Mount the host output directory into the container and run the user
     # script from that working directory so generated files land on the mount.

--- a/circuitron/ui/app.py
+++ b/circuitron/ui/app.py
@@ -269,7 +269,6 @@ class TerminalUI:
     ) -> None:
         """Render a compact summary panel with time, tokens, and cost."""
         from .components import panel as panel_comp
-        from rich.markup import escape
 
         overall = token_summary.get("overall", {})
         i = int(overall.get("input", 0))

--- a/circuitron/ui/app.py
+++ b/circuitron/ui/app.py
@@ -1,6 +1,6 @@
 """Terminal UI implementation using Rich and prompt_toolkit."""
 
-from typing import Iterable, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 from rich.console import Console
 
 
@@ -137,7 +137,9 @@ class TerminalUI:
             success = bool(files.get("success", False))
             stdout = str(files.get("stdout", "")).strip()
             stderr = str(files.get("stderr", "")).strip()
-            file_list = tuple(str(p) for p in files.get("files", []) if isinstance(p, str))
+            files_val = files.get("files", [])
+            files_iter = files_val if isinstance(files_val, Iterable) else []
+            file_list = tuple(str(p) for p in files_iter if isinstance(p, str))
 
             status = "Success" if success else "Completed with issues"
             status_style = "green" if success else "yellow"
@@ -250,7 +252,10 @@ class TerminalUI:
                 if total_cost == 0.0:
                     from ..config import settings as cfg
                     # Use code_generation_model as representative of main cost; user can change via /model
-                    model_name = getattr(cfg, "code_generation_model", None) or getattr(cfg, "planning_model", "o4-mini")
+                    model_name = str(
+                        getattr(cfg, "code_generation_model", None)
+                        or getattr(cfg, "planning_model", "o4-mini")
+                    )
                     total_cost2, used_default2 = estimate_cost_usd_for_model(token_summary, model_name)
                     # Prefer non-zero fallback
                     if total_cost2 > 0.0 or used_default:
@@ -263,7 +268,7 @@ class TerminalUI:
     def display_summary_stats(
         self,
         elapsed_seconds: float,
-        token_summary: dict,
+        token_summary: Mapping[str, Any],
         total_cost_usd: float,
         used_default_prices: bool,
     ) -> None:

--- a/circuitron/ui/components/completion.py
+++ b/circuitron/ui/components/completion.py
@@ -6,10 +6,10 @@ contextual dropdowns (e.g., available model names) with arrow key navigation.
 
 from __future__ import annotations
 
-from typing import Iterable, Iterator
+from typing import Iterable
 
-from prompt_toolkit.completion import Completer, Completion  # type: ignore
-from prompt_toolkit.document import Document  # type: ignore
+from prompt_toolkit.completion import Completer, Completion, CompleteEvent
+from prompt_toolkit.document import Document
 
 
 class SlashCommandCompleter(Completer):
@@ -41,7 +41,7 @@ class SlashCommandCompleter(Completer):
         self._themes = list(themes or [])
         self._cmd_desc = dict(command_descriptions or {})
 
-    def get_completions(self, document: Document, complete_event) -> Iterator[Completion]:  # type: ignore[override]
+    def get_completions(self, document: Document, complete_event: CompleteEvent) -> Iterable[Completion]:
         text = document.text
         # Cursor-aware current word/prefix
         word_before_cursor = document.get_word_before_cursor(WORD=True)
@@ -90,7 +90,7 @@ class SlashCommandCompleter(Completer):
             return
 
         # No suggestions for other contexts
-        return iter(())
+        return
 
 
 class ModelMenuCompleter(Completer):
@@ -106,7 +106,7 @@ class ModelMenuCompleter(Completer):
     def __init__(self, models: Iterable[str]) -> None:
         self._models = list(models)
 
-    def get_completions(self, document: Document, complete_event) -> Iterator[Completion]:  # type: ignore[override]
+    def get_completions(self, document: Document, complete_event: CompleteEvent) -> Iterable[Completion]:
         text = document.text
         word_before_cursor = document.get_word_before_cursor(WORD=True)
 

--- a/circuitron/ui/components/input_box.py
+++ b/circuitron/ui/components/input_box.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from rich.console import Console
 import asyncio
-from prompt_toolkit import PromptSession  # type: ignore
-from prompt_toolkit.history import InMemoryHistory  # type: ignore
-from prompt_toolkit.formatted_text import HTML  # type: ignore
-from prompt_toolkit.shortcuts import CompleteStyle  # type: ignore
-from prompt_toolkit.key_binding import KeyBindings  # type: ignore
+from prompt_toolkit import PromptSession
+from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.formatted_text import HTML
+from prompt_toolkit.shortcuts import CompleteStyle
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.completion import Completer
 
 from .completion import SlashCommandCompleter
 from ...config import settings
@@ -31,13 +32,13 @@ class InputBox:
 
     def __init__(self, console: Console) -> None:
         self.console = console
-        self._session: PromptSession | None = None
+        self._session: PromptSession[str] | None = None
         # Supported models for completion are sourced from settings.
         self._available_models: list[str] = list(
             getattr(settings, "available_models", ["o4-mini", "gpt-5-mini"])
         )
 
-    def ask(self, message: str, completer=None) -> str:
+    def ask(self, message: str, completer: Completer | None = None) -> str:
         """Return user input for ``message`` using prompt_toolkit when safe.
 
         Falls back to a boxed input() in async/headless environments.

--- a/circuitron/ui/components/panel.py
+++ b/circuitron/ui/components/panel.py
@@ -8,7 +8,7 @@ text instead of printing the literal tags.
 
 from __future__ import annotations
 
-from rich.console import Console
+from rich.console import Console, RenderableType
 from rich.text import Text
 from rich.markdown import Markdown
 from rich.panel import Panel
@@ -29,7 +29,7 @@ def show_panel(console: Console, title: str, content: str, *, render: str = "mar
             - "plain": render content as plain text with no special parsing
     """
     if render == "markup":
-        body = Text.from_markup(content)
+        body: RenderableType = Text.from_markup(content)
     elif render == "plain":
         body = Text(content)
     else:  # markdown

--- a/circuitron/ui/components/prompt.py
+++ b/circuitron/ui/components/prompt.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from prompt_toolkit import PromptSession  # type: ignore
-from prompt_toolkit.history import FileHistory  # type: ignore
-from prompt_toolkit.key_binding import KeyBindings  # type: ignore
-from prompt_toolkit.formatted_text import HTML  # type: ignore
+from prompt_toolkit import PromptSession
+from prompt_toolkit.history import FileHistory
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.formatted_text import HTML
 from rich.console import Console
 
 ACCENT = "cyan"
@@ -18,7 +18,7 @@ class Prompt:
 
     def __init__(self, console: Console) -> None:
         self.console = console
-        self._session: PromptSession | None = None
+        self._session: PromptSession[str] | None = None
         self._history_file = Path.home() / ".circuitron_history"
         self._bindings = KeyBindings()
         self._bindings.add("c-a")(lambda event: event.current_buffer.cursor_home())

--- a/circuitron/ui/components/status_bar.py
+++ b/circuitron/ui/components/status_bar.py
@@ -28,7 +28,7 @@ class StatusBar:
         self.console = console
         self.status = Status()
         self.started = False
-        self._last_rendered = None  # type: ignore[assignment]
+        self._last_rendered: tuple[str, str] | None = None
 
     def start(self) -> None:
         self.started = True

--- a/docs/migrations/MIGRATION_OPENAI_AGENTS_0_2_10.md
+++ b/docs/migrations/MIGRATION_OPENAI_AGENTS_0_2_10.md
@@ -1,0 +1,28 @@
+# Migration Guide: OpenAI Agents SDK 0.2.10
+
+This repository has been upgraded from **openai-agents 0.1.0** to
+**openai-agents 0.2.10**. The 0.2.x line introduces minor breaking
+changes and new type requirements.
+
+## Summary of Upstream Changes
+- [`ToolContext` now requires a `tool_name` argument](https://openai.github.io/openai-agents-python/agents/tools/).
+- Several APIs now accept `AgentBase` instead of `Agent` for type hints
+  ([release notes](https://raw.githubusercontent.com/openai/openai-agents-python/main/docs/release.md)).
+
+## Circuitron Updates
+- Added `tool_name` whenever `ToolContext` is instantiated in tests.
+- Patched CLI tests to mock `check_internet_connection` and
+  `TerminalUI.prompt_user` to avoid real network calls and interactive
+  prompts.
+- Fixed `execute_final_script` mounting logic to default to
+  `/workspace` on Unix paths.
+- Added `scripts/run_compat.py` to run the test suite against arbitrary
+  SDK versions.
+
+## Behavior Notes
+- No user‑facing CLI changes were introduced.
+- Tests and tool adapters now require explicit tool names when using
+  `ToolContext`.
+
+Refer to the [OpenAI Agents SDK documentation](https://openai.github.io/openai-agents-python/)
+for additional details and examples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = [{name = "Shaurya Sethi"}]
 requires-python = ">=3.10"
 dependencies = [
-    "openai-agents==0.1.0",
+    "openai-agents==0.2.10",
     "python-dotenv>=1.1.0",
     "skidl>=2.0.1",
     "httpx>=0.27.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai-agents==0.1.0
+openai-agents==0.2.10
 python-dotenv>=1.1.0
 skidl>=2.0.1
 httpx>=0.27.0

--- a/scripts/run_compat.py
+++ b/scripts/run_compat.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Run the test suite against a specific openai-agents version.
+
+Creates a temporary virtual environment, installs dependencies with the
+requested ``openai-agents`` version, installs the project in editable
+mode without its dependencies, and finally runs ``pytest -q``.
+"""
+import argparse
+import subprocess
+import tempfile
+import venv
+from pathlib import Path
+
+
+def run(version: str) -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        venv.create(tmp, with_pip=True)
+        py = Path(tmp) / "bin" / "python"
+        # Prepare requirements with the desired agents version
+        req_text = Path("requirements.txt").read_text().splitlines()
+        req_lines = [
+            (f"openai-agents=={version}" if line.startswith("openai-agents") else line)
+            for line in req_text
+            if line and not line.startswith("#")
+        ]
+        req_file = Path(tmp) / "reqs.txt"
+        req_file.write_text("\n".join(req_lines))
+        subprocess.check_call([str(py), "-m", "pip", "install", "-r", str(req_file)])
+        subprocess.check_call([str(py), "-m", "pip", "install", "pytest"])
+        subprocess.check_call([str(py), "-m", "pip", "install", "-e", ".", "--no-deps"])
+        return subprocess.call([str(py), "-m", "pytest", "-q"])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="openai-agents version to test against")
+    args = parser.parse_args()
+    raise SystemExit(run(args.version))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ def test_cli_main_uses_args_and_prints(capsys: pytest.CaptureFixture[str]) -> No
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
+         patch("circuitron.cli.check_internet_connection", return_value=True), \
          patch("circuitron.ui.app.TerminalUI.run", AsyncMock(return_value=out)):
         cli.main()
     captured = capsys.readouterr().out
@@ -51,8 +52,9 @@ def test_cli_main_prompts_for_input(monkeypatch: pytest.MonkeyPatch) -> None:
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
-         patch("circuitron.ui.app.TerminalUI.run", AsyncMock(return_value=out)) as run_mock:
-        monkeypatch.setattr("builtins.input", lambda _: "hello")
+         patch("circuitron.cli.check_internet_connection", return_value=True), \
+         patch("circuitron.ui.app.TerminalUI.run", AsyncMock(return_value=out)) as run_mock, \
+         patch("circuitron.ui.app.TerminalUI.prompt_user", return_value="hello"):
         cli.main()
         run_mock.assert_awaited_with(
             "hello", show_reasoning=True, retries=0, output_dir=None, keep_skidl=False
@@ -66,6 +68,7 @@ def test_cli_main_uses_keep_skidl_flag() -> None:
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
+         patch("circuitron.cli.check_internet_connection", return_value=True), \
          patch("circuitron.ui.app.TerminalUI.run", AsyncMock(return_value=out)) as run_mock, \
          patch("circuitron.tools.kicad_session.stop"):
         cli.main()
@@ -87,6 +90,7 @@ def test_cli_main_stops_session() -> None:
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
+         patch("circuitron.cli.check_internet_connection", return_value=True), \
          patch("circuitron.ui.app.TerminalUI.run", AsyncMock(return_value=out)), \
          patch("circuitron.tools.kicad_session.stop") as stop_mock:
         cli.main()
@@ -100,6 +104,7 @@ def test_cli_main_handles_exit_during_run(capsys: pytest.CaptureFixture[str], ex
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
+         patch("circuitron.cli.check_internet_connection", return_value=True), \
          patch("circuitron.ui.app.TerminalUI.run", AsyncMock(side_effect=exc_type)), \
          patch("circuitron.tools.kicad_session.stop"):
         cli.main()
@@ -112,6 +117,7 @@ def test_cli_main_handles_escape_during_prompt(capsys: pytest.CaptureFixture[str
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
+         patch("circuitron.cli.check_internet_connection", return_value=True), \
          patch("circuitron.ui.app.TerminalUI.prompt_user", side_effect=EOFError), \
          patch("circuitron.ui.app.TerminalUI.run", AsyncMock()) as run_mock, \
          patch("circuitron.tools.kicad_session.stop"):
@@ -126,6 +132,7 @@ def test_cli_main_handles_exception(capsys: pytest.CaptureFixture[str]) -> None:
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
+         patch("circuitron.cli.check_internet_connection", return_value=True), \
          patch("circuitron.ui.app.TerminalUI.run", AsyncMock(side_effect=RuntimeError("fail"))), \
          patch("circuitron.tools.kicad_session.stop"):
         cli.main()
@@ -183,6 +190,7 @@ def test_cli_main_sets_footprint_flag() -> None:
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
+         patch("circuitron.cli.check_internet_connection", return_value=True), \
          patch("circuitron.ui.app.TerminalUI.run", AsyncMock(return_value=out)), \
          patch("circuitron.tools.kicad_session.stop"):
         cli.main()
@@ -220,6 +228,7 @@ def test_cli_dev_mode_shows_run_items(capsys: pytest.CaptureFixture[str]) -> Non
          patch("circuitron.cli.setup_environment", side_effect=lambda dev, **kwargs: setattr(cfg.settings, "dev_mode", dev)), \
          patch("circuitron.debug.Runner.run", AsyncMock(return_value=run_result)), \
          patch("circuitron.ui.app.TerminalUI.run", AsyncMock(side_effect=fake_run)), \
+         patch("circuitron.cli.check_internet_connection", return_value=True), \
          patch("circuitron.tools.kicad_session.start"), \
          patch("circuitron.tools.kicad_session.stop"), \
          patch("circuitron.debug.display_run_items", wraps=dbg.display_run_items) as disp_mock:

--- a/tests/test_cost_and_telemetry.py
+++ b/tests/test_cost_and_telemetry.py
@@ -21,7 +21,7 @@ def test_token_usage_aggregator_basic() -> None:
 
 
 def test_cost_estimator_without_local_prices(monkeypatch) -> None:
-    import importlib, sys
+    import importlib
     # Ensure built-in/env prices are not used
     sys.modules.pop('circuitron._model_prices_local', None)
     monkeypatch.delenv('CIRCUITRON_PRICES_FILE', raising=False)

--- a/tests/test_fixed_search.py
+++ b/tests/test_fixed_search.py
@@ -51,7 +51,9 @@ def test_search_kicad_libraries_parses_stdout() -> None:
         "circuitron.tools.kicad_session.exec_python_with_env",
         side_effect=lambda script, timeout=120: _fake_exec_python_search(script, timeout),
     ):
-        ctx = ToolContext(context=None, tool_call_id="t_fixed1")
+        ctx = ToolContext(
+            context=None, tool_call_id="t_fixed1", tool_name="search_kicad_libraries"
+        )
         args = json.dumps({"query": "R"})
         result: str = asyncio.run(
             cast(
@@ -70,7 +72,9 @@ def test_search_kicad_footprints_parses_stdout() -> None:
         "circuitron.tools.kicad_session.exec_python_with_env",
         side_effect=lambda script, timeout=120: _fake_exec_python_footprints(script, timeout),
     ):
-        ctx = ToolContext(context=None, tool_call_id="t_fixed2")
+        ctx = ToolContext(
+            context=None, tool_call_id="t_fixed2", tool_name="search_kicad_footprints"
+        )
         args = json.dumps({"query": "SOIC"})
         result: str = asyncio.run(
             cast(

--- a/tests/test_output_generation.py
+++ b/tests/test_output_generation.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import subprocess
 from typing import Dict
 
 import json

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -20,7 +20,9 @@ def test_search_kicad_libraries() -> None:
     with patch(
         "circuitron.tools.kicad_session.exec_python_with_env", return_value=completed
     ) as run_mock:
-        ctx = ToolContext(context=None, tool_call_id="t1")
+        ctx = ToolContext(
+            context=None, tool_call_id="t1", tool_name="search_kicad_libraries"
+        )
         args = json.dumps({"query": "opamp lm324"})
         result: str = asyncio.run(
             cast(
@@ -41,7 +43,9 @@ def test_search_kicad_libraries_timeout() -> None:
         "circuitron.tools.kicad_session.exec_python_with_env",
         side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
     ):
-        ctx = ToolContext(context=None, tool_call_id="t2")
+        ctx = ToolContext(
+            context=None, tool_call_id="t2", tool_name="search_kicad_libraries"
+        )
         args = json.dumps({"query": "123"})
         result: str = asyncio.run(
             cast(
@@ -63,7 +67,9 @@ def test_search_kicad_footprints() -> None:
     with patch(
         "circuitron.tools.kicad_session.exec_python_with_env", return_value=completed
     ) as run_mock:
-        ctx = ToolContext(context=None, tool_call_id="t3")
+        ctx = ToolContext(
+            context=None, tool_call_id="t3", tool_name="search_kicad_footprints"
+        )
         args = json.dumps({"query": "SOIC-8"})
         result: str = asyncio.run(
             cast(
@@ -84,7 +90,9 @@ def test_search_kicad_footprints_timeout() -> None:
         "circuitron.tools.kicad_session.exec_python_with_env",
         side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
     ):
-        ctx = ToolContext(context=None, tool_call_id="t4")
+        ctx = ToolContext(
+            context=None, tool_call_id="t4", tool_name="search_kicad_footprints"
+        )
         args = json.dumps({"query": "DIP"})
         result: str = asyncio.run(
             cast(
@@ -106,7 +114,9 @@ def test_extract_pin_details() -> None:
     with patch(
         "circuitron.tools.kicad_session.exec_python_with_env", return_value=completed
     ) as run_mock:
-        ctx = ToolContext(context=None, tool_call_id="t5")
+        ctx = ToolContext(
+            context=None, tool_call_id="t5", tool_name="extract_pin_details"
+        )
         args = json.dumps({"library": "linear", "part_name": "lm386"})
         result: str = asyncio.run(
             cast(
@@ -126,7 +136,9 @@ def test_extract_pin_details_timeout() -> None:
         "circuitron.tools.kicad_session.exec_python_with_env",
         side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
     ):
-        ctx = ToolContext(context=None, tool_call_id="t6")
+        ctx = ToolContext(
+            context=None, tool_call_id="t6", tool_name="extract_pin_details"
+        )
         args = json.dumps({"library": "lin", "part_name": "bad"})
         result: str = asyncio.run(
             cast(
@@ -158,7 +170,9 @@ def test_run_erc_success() -> None:
     with patch(
         "circuitron.tools.kicad_session.exec_erc_with_env", return_value=completed
     ) as run_mock:
-        ctx = ToolContext(context=None, tool_call_id="t7")
+        ctx = ToolContext(
+            context=None, tool_call_id="t7", tool_name="run_erc"
+        )
         args = json.dumps({"script_path": "/tmp/a.py"})
         result: str = asyncio.run(
             cast(Coroutine[Any, Any, str], run_erc_tool.on_invoke_tool(ctx, args))
@@ -175,7 +189,9 @@ def test_run_erc_timeout() -> None:
         "circuitron.tools.kicad_session.exec_erc_with_env",
         side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=60),
     ):
-        ctx = ToolContext(context=None, tool_call_id="t8")
+        ctx = ToolContext(
+            context=None, tool_call_id="t8", tool_name="run_erc"
+        )
         args = json.dumps({"script_path": "/tmp/a.py"})
         result: str = asyncio.run(
             cast(Coroutine[Any, Any, str], run_erc_tool.on_invoke_tool(ctx, args))
@@ -199,7 +215,9 @@ def test_kicad_session_start_once() -> None:
         patch.object(kicad_session, "_run", return_value=fake_proc) as _run_mock,
         patch.object(kicad_session, "start", side_effect=fake_start) as start_mock,
     ):
-        ctx = ToolContext(context=None, tool_call_id="t9")
+        ctx = ToolContext(
+            context=None, tool_call_id="t9", tool_name="search_kicad_libraries"
+        )
         args = json.dumps({"query": "foo"})
         asyncio.run(
             cast(
@@ -237,7 +255,9 @@ def test_execute_final_script() -> None:
         sess.exec_full_script_with_env.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="ok", stderr=""
         )
-        ctx = ToolContext(context=None, tool_call_id="tf")
+        ctx = ToolContext(
+            context=None, tool_call_id="tf", tool_name="execute_final_script"
+        )
         args = json.dumps({"script_content": "code", "output_dir": "/tmp/out"})
         result: str = asyncio.run(
             cast(Coroutine[Any, Any, str], execute_final_script_tool.on_invoke_tool(ctx, args))
@@ -264,7 +284,9 @@ def test_execute_final_script_windows_path() -> None:
         sess.exec_full_script_with_env.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="ok", stderr=""
         )
-        ctx = ToolContext(context=None, tool_call_id="tfw")
+        ctx = ToolContext(
+            context=None, tool_call_id="tfw", tool_name="execute_final_script"
+        )
         args = json.dumps({"script_content": "code", "output_dir": "C:\\out", "keep_skidl": False})
         result: str = asyncio.run(
             cast(Coroutine[Any, Any, str], execute_final_script_tool.on_invoke_tool(ctx, args))
@@ -297,7 +319,9 @@ def test_execute_final_script_with_keep_skidl() -> None:
         )
         
         script_content = "from skidl import *\nprint('test')"
-        ctx = ToolContext(context=None, tool_call_id="tks")
+        ctx = ToolContext(
+            context=None, tool_call_id="tks", tool_name="execute_final_script"
+        )
         args = json.dumps({
             "script_content": script_content, 
             "output_dir": "/tmp/out", 
@@ -338,7 +362,9 @@ def test_execute_final_script_without_keep_skidl() -> None:
             args=[], returncode=0, stdout="ok", stderr=""
         )
         
-        ctx = ToolContext(context=None, tool_call_id="tnks")
+        ctx = ToolContext(
+            context=None, tool_call_id="tnks", tool_name="execute_final_script"
+        )
         args = json.dumps({
             "script_content": "from skidl import *", 
             "output_dir": "/tmp/out", 

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -246,7 +246,9 @@ def test_get_kg_usage_guide() -> None:
     import asyncio
     from typing import Any, Coroutine, cast
 
-    ctx = ToolContext(context=None, tool_call_id="kg1")
+    ctx = ToolContext(
+        context=None, tool_call_id="kg1", tool_name="get_kg_usage_guide"
+    )
     args = json.dumps({"task_type": "method"})
     guide = asyncio.run(
         cast(Coroutine[Any, Any, str], get_kg_usage_guide.on_invoke_tool(ctx, args))
@@ -262,7 +264,9 @@ def test_get_kg_usage_guide_new_categories() -> None:
     import asyncio
     from typing import Any, Coroutine, cast
 
-    ctx = ToolContext(context=None, tool_call_id="kg2")
+    ctx = ToolContext(
+        context=None, tool_call_id="kg2", tool_name="get_kg_usage_guide"
+    )
     categories = {
         "workflow": "ESSENTIAL KNOWLEDGE GRAPH WORKFLOW",
         "schema": "KNOWLEDGE GRAPH SCHEMA",


### PR DESCRIPTION
## Summary
- upgrade to openai-agents 0.2.10 and add compat test runner
- update tool and CLI tests for new ToolContext requirements
- document SDK migration

## Testing
- `scripts/run_compat.py 0.2.10`
- `pytest -q`
- `ruff check .`
- `mypy --strict circuitron` *(fails: unused type ignores and missing annotations)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bae2ca5c83339c677edeeef2465f