### PR TITLE
Enable default artifact saving and schematic generation without footprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,14 +178,11 @@ circuitron --dev "Design a voltage divider"
 
 The `--output-dir` option saves all generated files to a specific location. By default results are written to `./circuitron_output`.
 
-The `--keep-skidl` option saves the generated SKiDL script code to the output directory as `circuitron_skidl_script.py`. This is useful for debugging, education, and understanding how the circuit design was generated:
 
-```bash
-circuitron --keep-skidl "Design a voltage divider"
-```
+Circuitron automatically saves the final SKiDL script and the revised design plan in the output directory. Filenames are derived from your prompt (e.g., `voltage_divider.py`, `voltage_divider_design_plan.txt`) and numbered when duplicates exist.
 
 > **Note:**
-> It is currently recommended to use the `--no-footprint-search` flag to disable footprint searches. This ensures that SVG images and netlists are reliably generated. Not using this flag may lead to unstable behavior: sometimes the agent finds actual footprints and generates PCB layouts, but other times the pipeline fails due to hallucinated footprint names.
+> Use the `--no-footprint-search` flag to skip PCB layout generation. Schematic files will still be produced via `generate_schematic()` even when footprints are not searched.
 
 ### Cost Estimation and Pricing
 

--- a/circuitron/cli.py
+++ b/circuitron/cli.py
@@ -114,7 +114,6 @@ def main() -> None:
     show_reasoning = args.reasoning
     retries = args.retries
     output_dir = args.output_dir
-    keep_skidl = args.keep_skidl
 
     code_output: CodeGenerationOutput | None = None
     try:
@@ -125,7 +124,6 @@ def main() -> None:
                     show_reasoning=show_reasoning,
                     retries=retries,
                     output_dir=output_dir,
-                    keep_skidl=keep_skidl,
                 )
             )
         except (KeyboardInterrupt, EOFError):

--- a/circuitron/ui/app.py
+++ b/circuitron/ui/app.py
@@ -211,7 +211,6 @@ class TerminalUI:
         show_reasoning: bool = False,
         retries: int = 0,
         output_dir: str | None = None,
-        keep_skidl: bool = False,
     ) -> CodeGenerationOutput | None:
         """Execute the Circuitron pipeline with UI feedback.
 
@@ -235,7 +234,6 @@ class TerminalUI:
                 show_reasoning=show_reasoning,
                 retries=retries,
                 output_dir=output_dir,
-                keep_skidl=keep_skidl,
                 ui=self,
             )
         finally:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,11 +11,15 @@ import pytest
 
 def test_run_circuitron_invokes_pipeline() -> None:
     out = CodeGenerationOutput(complete_skidl_code="code")
-    async def fake_pipeline(prompt: str, show_reasoning: bool = False, retries: int = 0, output_dir: str | None = None, keep_skidl: bool = False) -> CodeGenerationOutput:
+    async def fake_pipeline(
+        prompt: str,
+        show_reasoning: bool = False,
+        retries: int = 0,
+        output_dir: str | None = None,
+    ) -> CodeGenerationOutput:
         assert prompt == "p"
         assert show_reasoning is True
         assert retries == 1
-        assert keep_skidl is False
         return out
 
     with patch("circuitron.pipeline.run_with_retry", AsyncMock(side_effect=fake_pipeline)):
@@ -34,7 +38,7 @@ def test_run_circuitron_handles_pipeline_error() -> None:
 
 def test_cli_main_uses_args_and_prints(capsys: pytest.CaptureFixture[str]) -> None:
     out = CodeGenerationOutput(complete_skidl_code="abc")
-    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False, keep_skidl=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
@@ -48,7 +52,7 @@ def test_cli_main_uses_args_and_prints(capsys: pytest.CaptureFixture[str]) -> No
 
 def test_cli_main_prompts_for_input(monkeypatch: pytest.MonkeyPatch) -> None:
     out = CodeGenerationOutput(complete_skidl_code="xyz")
-    args = SimpleNamespace(prompt=None, reasoning=True, retries=0, dev=False, output_dir=None, no_footprint_search=False, keep_skidl=False)
+    args = SimpleNamespace(prompt=None, reasoning=True, retries=0, dev=False, output_dir=None, no_footprint_search=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
@@ -57,24 +61,9 @@ def test_cli_main_prompts_for_input(monkeypatch: pytest.MonkeyPatch) -> None:
          patch("circuitron.ui.app.TerminalUI.prompt_user", return_value="hello"):
         cli.main()
         run_mock.assert_awaited_with(
-            "hello", show_reasoning=True, retries=0, output_dir=None, keep_skidl=False
+            "hello", show_reasoning=True, retries=0, output_dir=None
         )
 
-
-def test_cli_main_uses_keep_skidl_flag() -> None:
-    """Test that CLI main function passes keep_skidl flag from args to UI.run()."""
-    out = CodeGenerationOutput(complete_skidl_code="test")
-    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False, keep_skidl=True)
-    with patch("circuitron.cli.setup_environment"), \
-         patch("circuitron.pipeline.parse_args", return_value=args), \
-         patch("circuitron.tools.kicad_session.start"), \
-         patch("circuitron.cli.check_internet_connection", return_value=True), \
-         patch("circuitron.ui.app.TerminalUI.run", AsyncMock(return_value=out)) as run_mock, \
-         patch("circuitron.tools.kicad_session.stop"):
-        cli.main()
-        run_mock.assert_awaited_with(
-            "p", show_reasoning=False, retries=0, output_dir=None, keep_skidl=True
-        )
 
 
 def test_module_main_called() -> None:
@@ -86,7 +75,7 @@ def test_module_main_called() -> None:
 
 def test_cli_main_stops_session() -> None:
     out = CodeGenerationOutput(complete_skidl_code="123")
-    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False, keep_skidl=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
@@ -100,7 +89,7 @@ def test_cli_main_stops_session() -> None:
 def test_cli_main_handles_exit_during_run(capsys: pytest.CaptureFixture[str], exc_type: type[BaseException]) -> None:
     import circuitron.config as cfg
     cfg.setup_environment()
-    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False, keep_skidl=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
@@ -113,7 +102,7 @@ def test_cli_main_handles_exit_during_run(capsys: pytest.CaptureFixture[str], ex
 
 
 def test_cli_main_handles_escape_during_prompt(capsys: pytest.CaptureFixture[str]) -> None:
-    args = SimpleNamespace(prompt=None, reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False, keep_skidl=False)
+    args = SimpleNamespace(prompt=None, reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
@@ -128,7 +117,7 @@ def test_cli_main_handles_escape_during_prompt(capsys: pytest.CaptureFixture[str
 
 
 def test_cli_main_handles_exception(capsys: pytest.CaptureFixture[str]) -> None:
-    args = SimpleNamespace(prompt="p", reasoning=False, retries=1, dev=False, output_dir=None, no_footprint_search=False, keep_skidl=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, retries=1, dev=False, output_dir=None, no_footprint_search=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.tools.kicad_session.start"), \
@@ -157,7 +146,7 @@ def test_verify_containers_failure(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_cli_main_no_prompt_on_container_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    args = SimpleNamespace(prompt=None, reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False, keep_skidl=False)
+    args = SimpleNamespace(prompt=None, reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False)
     out = CodeGenerationOutput(complete_skidl_code="")
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
@@ -170,7 +159,7 @@ def test_cli_main_no_prompt_on_container_failure(monkeypatch: pytest.MonkeyPatch
 
 
 def test_cli_main_checks_internet(monkeypatch: pytest.MonkeyPatch) -> None:
-    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False, keep_skidl=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=False)
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.cli.check_internet_connection", return_value=False), \
@@ -185,7 +174,7 @@ def test_cli_main_checks_internet(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_cli_main_sets_footprint_flag() -> None:
     import circuitron.config as cfg
     cfg.setup_environment()
-    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=True, keep_skidl=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=False, output_dir=None, no_footprint_search=True)
     out = CodeGenerationOutput(complete_skidl_code="")
     with patch("circuitron.cli.setup_environment"), \
          patch("circuitron.pipeline.parse_args", return_value=args), \
@@ -219,11 +208,11 @@ def test_cli_dev_mode_shows_run_items(capsys: pytest.CaptureFixture[str]) -> Non
         ],
     )
 
-    async def fake_run(prompt: str, show_reasoning: bool = False, retries: int = 0, output_dir: str | None = None, keep_skidl: bool = False) -> CodeGenerationOutput:
+    async def fake_run(prompt: str, show_reasoning: bool = False, retries: int = 0, output_dir: str | None = None) -> CodeGenerationOutput:
         await dbg.run_agent(SimpleNamespace(name="A"), "hi")
         return CodeGenerationOutput(complete_skidl_code="code")
 
-    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=True, output_dir=None, no_footprint_search=False, keep_skidl=False)
+    args = SimpleNamespace(prompt="p", reasoning=False, retries=0, dev=True, output_dir=None, no_footprint_search=False)
     with patch("circuitron.pipeline.parse_args", return_value=args), \
          patch("circuitron.cli.setup_environment", side_effect=lambda dev, **kwargs: setattr(cfg.settings, "dev_mode", dev)), \
          patch("circuitron.debug.Runner.run", AsyncMock(return_value=run_result)), \

--- a/tests/test_output_generation.py
+++ b/tests/test_output_generation.py
@@ -70,7 +70,7 @@ def test_execute_final_script_mounts_workspace_and_copies(tmp_path, monkeypatch)
 
     # Act
     result_json = asyncio.run(
-        tools_mod.execute_final_script(script, str(out_dir), keep_skidl=False)
+        tools_mod.execute_final_script(script, str(out_dir), "design")
     )
     data = json.loads(result_json)
 
@@ -135,10 +135,10 @@ def test_execute_final_script_filters_preexisting_files(tmp_path, monkeypatch):
 
     # Act
     result_json = asyncio.run(
-        tools_mod.execute_final_script("from skidl import *\nERC()\n", str(out_dir), keep_skidl=False)
+    tools_mod.execute_final_script("from skidl import *\nERC()\n", str(out_dir), "design")
     )
     data = json.loads(result_json)
 
     # Assert: only the new files should be reported back
     returned = set(os.path.basename(p) for p in data.get("files", []))
-    assert returned == {"boost_converter.json", "boost_converter.svg"}
+    assert returned == {"boost_converter.json", "boost_converter.svg", "design.py"}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -97,24 +97,6 @@ def test_parse_args_no_footprint_flag() -> None:
     assert args.no_footprint_search is True
 
 
-def test_parse_args_keep_skidl_flag() -> None:
-    """Test that --keep-skidl argument is parsed correctly."""
-    from circuitron import pipeline as pl
-    
-    # Test default behavior (keep_skidl should default to False)
-    args_default = pl.parse_args(["prompt"])
-    assert args_default.keep_skidl is False
-    
-    # Test with --keep-skidl flag
-    args_with_flag = pl.parse_args(["prompt", "--keep-skidl"])
-    assert args_with_flag.keep_skidl is True
-    
-    # Test with other arguments combined
-    args_combined = pl.parse_args(["prompt", "--keep-skidl", "--output-dir", "/tmp", "-r"])
-    assert args_combined.keep_skidl is True
-    assert args_combined.output_dir == "/tmp"
-    assert args_combined.reasoning is True
-
 
 def test_run_code_validation_calls_erc() -> None:
     import circuitron.pipeline as pl

--- a/tests/test_utils_extra.py
+++ b/tests/test_utils_extra.py
@@ -330,10 +330,10 @@ generate_netlist()
 """
     
     # Test saving the script
-    keep_skidl_script(output_dir, script_content)
+    keep_skidl_script(output_dir, script_content, "my_design")
     
     # Verify the file was created with correct name and content
-    expected_path = tmp_path / "circuitron_skidl_script.py"
+    expected_path = tmp_path / "my_design.py"
     assert expected_path.exists(), "SKiDL script file should be created"
     
     # Verify content is correctly written
@@ -351,7 +351,7 @@ def test_keep_skidl_script_with_none_output_dir() -> None:
     from circuitron.utils import keep_skidl_script
     
     # Should not raise an exception when output_dir is None
-    keep_skidl_script(None, "some script content")
+    keep_skidl_script(None, "some script content", "design")
     # No assertion needed - just verify it doesn't crash
 
 
@@ -367,9 +367,9 @@ r1 = Part('Device', 'R', value='1kΩ')  # Greek Omega
 # Comment with emoji: ⚡ 
 """
     
-    keep_skidl_script(output_dir, script_content)
+    keep_skidl_script(output_dir, script_content, "unicode")
     
-    expected_path = tmp_path / "circuitron_skidl_script.py"
+    expected_path = tmp_path / "unicode.py"
     assert expected_path.exists()
     
     # Verify Unicode content is preserved
@@ -388,9 +388,9 @@ def test_keep_skidl_script_creates_missing_dir(tmp_path: Path) -> None:
     output_dir = tmp_path / "missing"
     script_content = "from skidl import *\n"
 
-    keep_skidl_script(str(output_dir), script_content)
+    keep_skidl_script(str(output_dir), script_content, "missing")
 
-    expected_path = output_dir / "circuitron_skidl_script.py"
+    expected_path = output_dir / "missing.py"
     assert expected_path.exists()
     with open(expected_path, encoding="utf-8") as f:
         assert f.read() == script_content
@@ -402,3 +402,13 @@ def test_convert_windows_path_for_docker() -> None:
     assert convert_windows_path_for_docker("/mnt/c/Users") == "/mnt/c/Users"
     with pytest.raises(ValueError):
         convert_windows_path_for_docker("not/a/windows/path")
+
+
+def test_save_design_plan(tmp_path: Path) -> None:
+    """Design plan is saved with a unique filename."""
+    from circuitron.utils import save_design_plan
+    from circuitron.models import PlanOutput
+
+    plan = PlanOutput()
+    save_design_plan(str(tmp_path), plan, "example")
+    assert (tmp_path / "example_design_plan.txt").exists()


### PR DESCRIPTION
## Summary
- Always persist generated SKiDL code and revised design plans using prompt-derived filenames
- Drop `--keep-skidl` flag and store artifacts by default
- When footprint search is disabled, skip PCB output but enforce schematic generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baab24e9f08333b59b9d7965664996