### PR TITLE
Propagation of --keep-skidl option was blocked.

### DIFF
--- a/circuitron/pipeline.py
+++ b/circuitron/pipeline.py
@@ -522,6 +522,7 @@ async def run_with_retry(
                 prompt,
                 show_reasoning=show_reasoning,
                 output_dir=output_dir,
+                keep_skidl=keep_skidl,
                 ui=ui,
             )
         except PipelineError:


### PR DESCRIPTION
`keep_skidl` parameter was missing from the call to `pipeline()`, so I added it.